### PR TITLE
Response-fixes-for-front-end

### DIFF
--- a/api.py
+++ b/api.py
@@ -167,13 +167,10 @@ def run_simulation(simulation_config: SimulationConfig, current_user: dict = Dep
         results = game_class.run_simulations(num_simulations, game_class, league, custom_rewards)
         
         if league_name != "test_league":
-            sim_id = save_simulation_results(session, league.id, results, custom_rewards)
+            sim_result = save_simulation_results(session, league.id, results, custom_rewards)
         
         # Only include custom_rewards in the response if they were provided
-        response_data = transform_result(results, sim_id)
-        if custom_rewards is not None:
-            response_data["custom_rewards"] = custom_rewards
-        
+        response_data = transform_result(results, sim_result, league.name) 
         return ResponseModel(status="success", message="Simulation run successfully", data=response_data)
     
     except Exception as e:

--- a/api.py
+++ b/api.py
@@ -6,7 +6,7 @@ from games.game_factory import GameFactory
 import os
 from config import ROOT_DIR
 from contextlib import asynccontextmanager
-from utils import transform_result
+from utils import transform_result, get_games_names
 from auth import get_current_user, decode_id
 import database
 from models_api import (
@@ -297,6 +297,20 @@ async def get_game_instructions(game: GameName):
                 "starter_code": game_class.starter_code,
                 "game_instructions": game_class.game_instructions
             }
+        )
+    except Exception as e:
+        return ErrorResponseModel(status="error", message=f"An error occurred: {str(e)}")
+    
+
+@app.post("/get_available_games", response_model=ResponseModel)
+async def get_available_game():
+    try:
+        game_names = get_games_names()
+        
+        return ResponseModel(
+            status="success",
+            message="Game instructions retrieved successfully",
+            data={ "games" :game_names }
         )
     except Exception as e:
         return ErrorResponseModel(status="error", message=f"An error occurred: {str(e)}")

--- a/database.py
+++ b/database.py
@@ -22,6 +22,9 @@ AUSTRALIA_SYDNEY_TZ = pytz.timezone('Australia/Sydney')
 class LeagueNotFoundError(Exception):
     pass
 
+class TeamAlreadyExistsError(Exception):
+    pass
+
 class TeamNotFoundError(Exception):
     pass
 
@@ -74,6 +77,13 @@ def create_team(session, name, password, league_id=1, school=None):
     if not league:
         raise LeagueNotFoundError(f"League with id '{league_id}' does not exist")
     
+    existing_team = session.exec(
+        select(Team)
+        .where(Team.name == name)
+    ).one_or_none()
+    if existing_team:
+        raise TeamAlreadyExistsError("Team already exists")
+
     team = Team(name=name, school_name=school)
     team.set_password(password)
     session.add(team)

--- a/database.py
+++ b/database.py
@@ -78,12 +78,8 @@ def create_team(session, name, password, league_id=1, school=None):
     team.league = league
     session.commit()
 
-    access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
-    access_token = create_access_token(
-        data={"sub": name, "role": "student"},
-        expires_delta=access_token_expires
-    )
-    return {"access_token": access_token, "token_type": "bearer"}
+    
+    return {"name": team.name, "id": team.id, "league_id": team.league_id, "league": team.league.name}
 
 
 def get_team_token(session, team_name, team_password):
@@ -263,7 +259,7 @@ def save_simulation_results(session, league_id, results, rewards=None):
             session.add(result_item)
 
     session.commit()
-    return simulation_result.id
+    return simulation_result
 
 
 def get_all_league_results_from_db(session, league_name):

--- a/tests/test_team.py
+++ b/tests/test_team.py
@@ -104,6 +104,7 @@ def test_team_create(client, db_session, admin_token):
     response = client.post("/team_create", json={"name": team_name, "password": team_password, "school_name": team_school}, headers={"Authorization": f"Bearer {admin_token}"})
     assert response.status_code == 200
     assert response.json()["status"] == "failed"
+    assert response.json()["message"] == "Server error: Team already exists"
 
     response = client.post("/team_create", json={"name": "missing_fields_team"}, headers={"Authorization": f"Bearer {admin_token}"})
     assert response.status_code == 422

--- a/tests/test_team.py
+++ b/tests/test_team.py
@@ -90,9 +90,11 @@ def test_team_create(client, db_session, admin_token):
     team_school = "new_test_school"
     response = client.post("/team_create", json={"name": team_name, "password": team_password, "school_name": team_school}, headers={"Authorization": f"Bearer {admin_token}"})
     assert response.status_code == 200
-    assert "access_token" in response.json()["data"]
-    assert response.json()["data"]["token_type"] == "bearer"
-
+    assert "name" in response.json()["data"]
+    assert "id" in response.json()["data"]
+    assert "league_id" in response.json()["data"]
+    assert "league" in response.json()["data"]
+    
     team = db_session.exec(select(Team).where(Team.name == team_name)).one_or_none()
     assert team is not None
     assert team.name == team_name

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,6 @@
 # utils.py
 
-import json
+import json, os
 from database import create_team
 
 def add_teams_from_json(session, teams_json_path):
@@ -44,3 +44,15 @@ def transform_result(result_data, sim_result, league_name):
         "total_wins": result_data["total_wins"],
 
     }
+
+def get_games_names():
+    games_directory = "./games"
+    if not os.path.exists(games_directory):
+        raise FileNotFoundError(f"The directory '{games_directory}' does not exist.")
+    
+    # List the contents of the games directory and filter only directories
+    game_names = [
+        folder for folder in os.listdir(games_directory)
+        if os.path.isdir(os.path.join(games_directory, folder)) and folder != "__pycache__"
+    ]
+    return game_names

--- a/utils.py
+++ b/utils.py
@@ -29,13 +29,18 @@ def add_teams_from_json(session, teams_json_path):
         raise ValueError(f"Error processing team data from JSON: {str(e)}")
     
 
-def transform_result(result_data, sim_id):
+def transform_result(result_data, sim_result, league_name):
     # Sort the total_points dictionary by values
     sorted_total_points = dict(sorted(result_data["total_points"].items(), key=lambda item: item[1], reverse=True))
 
     return {
+
+        "id": sim_result.id,
+        "league_name": league_name,
+        "num_simulations": result_data["num_simulations"],
+        "rewards": sim_result.custom_rewards,
+        "timestamp": sim_result.timestamp,
         "total_points": sorted_total_points,
         "total_wins": result_data["total_wins"],
-        "num_simulations": result_data["num_simulations"],
-        "simulation_id": sim_id
+
     }


### PR DESCRIPTION
Added get games_names endpoint.
Fixed object returns for run simulation.
Fixed same team creation error return.
Added rewards in response data in default rewards.