### PR TITLE
Refactor dockerfile to use virtualenv

### DIFF
--- a/backend/dockerfile
+++ b/backend/dockerfile
@@ -1,13 +1,27 @@
+FROM python:3.12 as builder
+
+WORKDIR /agent_games
+
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+RUN pip install orjson
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+
 # Deriving the latest base image
 FROM python:3.12
+COPY --from=builder /opt/venv /opt/venv
 
 # Install curl and Rust
 RUN apt-get update && apt-get install -y curl
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
-
-# Install orjson (now that Rust is available)
-RUN pip install orjson
+ENV PATH="/opt/venv/bin:$PATH"
 
 # Copy files
 COPY games /agent_games/games
@@ -20,9 +34,6 @@ COPY dockerfile_script.py /agent_games
 
 # Set working directory
 WORKDIR /agent_games
-
-# Install Python dependencies
-RUN pip install -r requirements.txt
 
 # Set the entrypoint
 ENTRYPOINT ["python", "dockerfile_script.py"]


### PR DESCRIPTION
This commit refactors the dockerfile to address the issue of the pip being run as root user. The refactoring uses a builder and copies the packages in the image. Reference: https://testdriven.io/blog/docker-best-practices.

Address the Issue #83 