### PR TITLE
Backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,7 @@ fabric.properties
 # End of https://www.toptal.com/developers/gitignore/api/pycharm+all
 code_documentation.md
 backend/.env
+.aws.env
 backend/games/arena_champions/validation_players.py
 .kamal/secrets
 

--- a/backend/docker_utils/Dockerfile
+++ b/backend/docker_utils/Dockerfile
@@ -29,7 +29,7 @@ ENV PATH="/agent_games/.venv/bin:$PATH"
 # Copy libpq from builder — no apk add needed for psycopg
 COPY --from=builder /usr/lib/libpq.so* /usr/lib/
 
-# Only install extra packages when needed (e.g. docker-cli for test-runner)
+# Only install extra packages when needed (e.g. postgresql18-client for api, docker-cli for test-runner)
 ARG RUNTIME_PACKAGES=""
 RUN if [ -n "$RUNTIME_PACKAGES" ]; then apk add --no-cache $RUNTIME_PACKAGES; fi
 

--- a/backend/routes/admin/admin_backup.py
+++ b/backend/routes/admin/admin_backup.py
@@ -1,0 +1,186 @@
+import logging
+import os
+import subprocess
+import tempfile
+from datetime import datetime
+from urllib.parse import urlparse
+
+import boto3
+from botocore.exceptions import ClientError
+
+from backend.database.db_config import get_database_url
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_db_url():
+    """Extract host, port, user, password, dbname from the SQLAlchemy DATABASE_URL."""
+    raw = get_database_url()
+    # Strip the +psycopg driver so urlparse handles it cleanly
+    raw = raw.replace("postgresql+psycopg://", "postgresql://")
+    parsed = urlparse(raw)
+    return {
+        "host": parsed.hostname or "localhost",
+        "port": str(parsed.port or 5432),
+        "user": parsed.username or "postgres",
+        "password": parsed.password or "",
+        "dbname": parsed.path.lstrip("/"),
+    }
+
+
+def _get_s3_client():
+    """Build a boto3 S3 client for AWS."""
+    key = os.environ.get("AWS_ACCESS_KEY_ID")
+    secret = os.environ.get("AWS_SECRET_ACCESS_KEY")
+    region = os.environ.get("AWS_REGION", "ap-southeast-2")
+    if not all([key, secret]):
+        raise ValueError(
+            "Missing AWS credentials. Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY."
+        )
+    return boto3.client(
+        "s3",
+        aws_access_key_id=key,
+        aws_secret_access_key=secret,
+        region_name=region,
+    )
+
+
+def create_backup() -> dict:
+    """Run pg_dump and upload the .sql file to AWS S3.
+
+    Returns a dict with backup metadata on success.
+    """
+    bucket = os.environ.get("AWS_S3_BUCKET", "agent-games-backups")
+    db = _parse_db_url()
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filename = f"agent_games_{timestamp}.sql"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        dump_path = os.path.join(tmp, filename)
+
+        env = os.environ.copy()
+        env["PGPASSWORD"] = db["password"]
+
+        result = subprocess.run(
+            [
+                "pg_dump",
+                "-h", db["host"],
+                "-p", db["port"],
+                "-U", db["user"],
+                "-d", db["dbname"],
+                "-f", dump_path,
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=120,
+        )
+
+        if result.returncode != 0:
+            raise RuntimeError(f"pg_dump failed: {result.stderr}")
+
+        file_size = os.path.getsize(dump_path)
+
+        # Upload to S3
+        client = _get_s3_client()
+        s3_key = f"backups/{filename}"
+        try:
+            client.upload_file(
+                dump_path,
+                bucket,
+                s3_key,
+                ExtraArgs={"ContentType": "application/sql"},
+            )
+        except ClientError as e:
+            raise RuntimeError(f"Failed to upload to S3: {e}")
+
+    logger.info(f"Backup uploaded: s3://{bucket}/{s3_key} ({file_size} bytes)")
+    return {
+        "filename": filename,
+        "s3_key": s3_key,
+        "bucket": bucket,
+        "size_bytes": file_size,
+        "timestamp": timestamp,
+    }
+
+
+def list_backups() -> list[dict]:
+    """List existing backups in the S3 bucket."""
+    bucket = os.environ.get("AWS_S3_BUCKET", "agent-games-backups")
+    client = _get_s3_client()
+
+    try:
+        response = client.list_objects_v2(Bucket=bucket, Prefix="backups/")
+    except ClientError as e:
+        raise RuntimeError(f"Failed to list backups: {e}")
+
+    backups = []
+    for obj in response.get("Contents", []):
+        backups.append({
+            "filename": obj["Key"].split("/")[-1],
+            "s3_key": obj["Key"],
+            "size_bytes": obj["Size"],
+            "last_modified": obj["LastModified"].isoformat(),
+        })
+
+    # Most recent first
+    backups.sort(key=lambda b: b["last_modified"], reverse=True)
+    return backups
+
+
+def restore_backup(s3_key: str) -> dict:
+    """Download a backup from S3 and restore it via psql.
+
+    This drops and recreates the database before restoring.
+    """
+    bucket = os.environ.get("AWS_S3_BUCKET", "agent-games-backups")
+    db = _parse_db_url()
+    client = _get_s3_client()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        filename = s3_key.split("/")[-1]
+        dump_path = os.path.join(tmp, filename)
+
+        # Download from S3
+        try:
+            client.download_file(bucket, s3_key, dump_path)
+        except ClientError as e:
+            raise RuntimeError(f"Failed to download backup from S3: {e}")
+
+        env = os.environ.copy()
+        env["PGPASSWORD"] = db["password"]
+        psql_base = ["psql", "-h", db["host"], "-p", db["port"], "-U", db["user"]]
+
+        # Terminate existing connections to the target database
+        result = subprocess.run(
+            psql_base + ["-d", "postgres", "-c",
+                         f"SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                         f"WHERE datname = '{db['dbname']}' AND pid <> pg_backend_pid();"],
+            capture_output=True, text=True, env=env, timeout=30,
+        )
+
+        # Drop and recreate the database
+        result = subprocess.run(
+            psql_base + ["-d", "postgres", "-c", f"DROP DATABASE IF EXISTS {db['dbname']};"],
+            capture_output=True, text=True, env=env, timeout=30,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"DROP DATABASE failed: {result.stderr}")
+
+        result = subprocess.run(
+            psql_base + ["-d", "postgres", "-c", f"CREATE DATABASE {db['dbname']};"],
+            capture_output=True, text=True, env=env, timeout=30,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"CREATE DATABASE failed: {result.stderr}")
+
+        # Restore the dump
+        result = subprocess.run(
+            psql_base + ["-d", db["dbname"], "-f", dump_path],
+            capture_output=True, text=True, env=env, timeout=300,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"psql restore failed: {result.stderr}")
+
+    logger.info(f"Database restored from s3://{bucket}/{s3_key}")
+    return {"filename": filename, "s3_key": s3_key}

--- a/backend/routes/admin/admin_db.py
+++ b/backend/routes/admin/admin_db.py
@@ -48,47 +48,42 @@ def create_institution(session: Session, institution_data: CreateInstitution) ->
             f"Institution with name '{institution_data.name}' already exists"
         )
 
-    try:
-        institution = Institution(
-            name=institution_data.name,
-            contact_person=institution_data.contact_person,
-            contact_email=institution_data.contact_email,
-            created_date=datetime.now(AUSTRALIA_SYDNEY_TZ),
-            subscription_active=True,
-            subscription_expiry=institution_data.subscription_expiry,
-            docker_access=institution_data.docker_access,
-        )
-        institution.set_password(institution_data.password)
+    institution = Institution(
+        name=institution_data.name,
+        contact_person=institution_data.contact_person,
+        contact_email=institution_data.contact_email,
+        created_date=datetime.now(AUSTRALIA_SYDNEY_TZ),
+        subscription_active=True,
+        subscription_expiry=institution_data.subscription_expiry,
+        docker_access=institution_data.docker_access,
+    )
+    institution.set_password(institution_data.password)
 
-        session.add(institution)
-        session.flush()  # Get the ID for the new institution
+    session.add(institution)
+    session.flush()  # Get the ID for the new institution
 
-        # Create unassigned league for this institution
-        unassigned_league = League(
-            name="unassigned",
-            created_date=datetime.now(AUSTRALIA_SYDNEY_TZ),
-            expiry_date=(
-                datetime.now(AUSTRALIA_SYDNEY_TZ)
-                + timedelta(days=365)  # Long expiry for unassigned league
-            ),
-            game="greedy_pig",  # Default game
-            league_type=LeagueType.INSTITUTION,
-            institution_id=institution.id,
-        )
-        session.add(unassigned_league)
+    # Create unassigned league for this institution
+    unassigned_league = League(
+        name="unassigned",
+        created_date=datetime.now(AUSTRALIA_SYDNEY_TZ),
+        expiry_date=(
+            datetime.now(AUSTRALIA_SYDNEY_TZ)
+            + timedelta(days=365)  # Long expiry for unassigned league
+        ),
+        game="greedy_pig",  # Default game
+        league_type=LeagueType.INSTITUTION,
+        institution_id=institution.id,
+    )
+    session.add(unassigned_league)
 
-        session.commit()
-        session.refresh(institution)
+    session.commit()
+    session.refresh(institution)
 
-        return {
-            "id": institution.id,
-            "name": institution.name,
-            "contact_person": institution.contact_person,
-        }
-    except Exception as e:
-        session.rollback()
-        logger.error(f"Error creating institution: {e}")
-        raise InstitutionError(f"Failed to create institution: {str(e)}")
+    return {
+        "id": institution.id,
+        "name": institution.name,
+        "contact_person": institution.contact_person,
+    }
 
 
 def update_institution(session: Session, institution_data: InstitutionUpdate) -> Dict:
@@ -124,10 +119,9 @@ def update_institution(session: Session, institution_data: InstitutionUpdate) ->
             "name": institution.name,
             "contact_person": institution.contact_person,
         }
-    except Exception as e:
+    except IntegrityError as e:
         session.rollback()
-        logger.error(f"Error updating institution: {e}")
-        raise InstitutionError(f"Failed to update institution: {str(e)}")
+        raise InstitutionError(f"Institution name '{institution_data.name}' already exists")
 
 
 def delete_institution(session: Session, institution_id: int) -> str:
@@ -137,77 +131,68 @@ def delete_institution(session: Session, institution_id: int) -> str:
     if not institution:
         raise InstitutionError(f"Institution with ID {institution_id} not found")
 
-    try:
-        # Get all teams for this institution
-        teams = session.exec(
-            select(Team).where(Team.institution_id == institution_id)
-        ).all()
+    # Get all teams for this institution
+    teams = session.exec(
+        select(Team).where(Team.institution_id == institution_id)
+    ).all()
 
-        team_ids = [team.id for team in teams]
+    team_ids = [team.id for team in teams]
 
-        # Delete submissions for these teams
-        session.exec(delete(Submission).where(Submission.team_id.in_(team_ids)))
+    # Delete submissions for these teams
+    session.exec(delete(Submission).where(Submission.team_id.in_(team_ids)))
 
-        # Delete simulation result items for these teams
-        session.exec(
-            delete(SimulationResultItem).where(
-                SimulationResultItem.team_id.in_(team_ids)
-            )
+    # Delete simulation result items for these teams
+    session.exec(
+        delete(SimulationResultItem).where(
+            SimulationResultItem.team_id.in_(team_ids)
         )
+    )
 
-        # Delete teams
-        session.exec(delete(Team).where(Team.institution_id == institution_id))
+    # Delete teams
+    session.exec(delete(Team).where(Team.institution_id == institution_id))
 
-        # Get leagues for this institution
-        leagues = session.exec(
-            select(League).where(League.institution_id == institution_id)
-        ).all()
+    # Get leagues for this institution
+    leagues = session.exec(
+        select(League).where(League.institution_id == institution_id)
+    ).all()
 
-        league_ids = [league.id for league in leagues]
+    league_ids = [league.id for league in leagues]
 
-        # Delete simulation results for these leagues
-        session.exec(
-            delete(SimulationResult).where(SimulationResult.league_id.in_(league_ids))
-        )
+    # Delete simulation results for these leagues
+    session.exec(
+        delete(SimulationResult).where(SimulationResult.league_id.in_(league_ids))
+    )
 
-        # Delete leagues
-        session.exec(delete(League).where(League.institution_id == institution_id))
+    # Delete leagues
+    session.exec(delete(League).where(League.institution_id == institution_id))
 
-        # Finally delete the institution
-        session.delete(institution)
-        session.commit()
+    # Finally delete the institution
+    session.delete(institution)
+    session.commit()
 
-        return f"Institution '{institution.name}' and all associated data deleted successfully"
-    except Exception as e:
-        session.rollback()
-        logger.error(f"Error deleting institution: {e}")
-        raise InstitutionError(f"Failed to delete institution: {str(e)}")
+    return f"Institution '{institution.name}' and all associated data deleted successfully"
 
 
 def get_all_institutions(session: Session) -> Dict:
     """Get all institutions"""
-    try:
-        institutions = session.exec(select(Institution)).all()
-        return {
-            "institutions": [
-                {
-                    "id": inst.id,
-                    "name": inst.name,
-                    "contact_person": inst.contact_person,
-                    "contact_email": inst.contact_email,
-                    "created_date": inst.created_date,
-                    "subscription_active": inst.subscription_active,
-                    "subscription_expiry": inst.subscription_expiry,
-                    "docker_access": inst.docker_access,
-                    "team_count": len(inst.teams),
-                    "league_count": len(inst.leagues),
-                }
-                for inst in institutions
-            ]
-        }
-    except Exception as e:
-        logger.error(f"Error retrieving institutions: {e}")
-        raise InstitutionError(f"Failed to retrieve institutions: {str(e)}")
+    institutions = session.exec(select(Institution)).all()
+    return {
+        "institutions": [
+            {
+                "id": inst.id,
+                "name": inst.name,
+                "contact_person": inst.contact_person,
+                "contact_email": inst.contact_email,
+                "created_date": inst.created_date,
+                "subscription_active": inst.subscription_active,
+                "subscription_expiry": inst.subscription_expiry,
+                "docker_access": inst.docker_access,
+                "team_count": len(inst.teams),
+                "league_count": len(inst.leagues),
+            }
+            for inst in institutions
+        ]
+    }
 
 
 def toggle_institution_docker_access(
@@ -219,17 +204,12 @@ def toggle_institution_docker_access(
     if not institution:
         raise InstitutionError(f"Institution with ID {institution_id} not found")
 
-    try:
-        institution.docker_access = enable
-        session.add(institution)
-        session.commit()
+    institution.docker_access = enable
+    session.add(institution)
+    session.commit()
 
-        status = "enabled" if enable else "disabled"
-        return f"Docker access {status} for institution '{institution.name}'"
-    except Exception as e:
-        session.rollback()
-        logger.error(f"Error toggling Docker access: {e}")
-        raise InstitutionError(f"Failed to toggle Docker access: {str(e)}")
+    status = "enabled" if enable else "disabled"
+    return f"Docker access {status} for institution '{institution.name}'"
 
 
 # Demo user management functions
@@ -237,42 +217,37 @@ def get_all_demo_users(session: Session):
     """
     Retrieve all demo users along with their team, league, and submission details.
     """
-    try:
-        demo_teams = session.exec(select(Team).where(Team.is_demo == True)).all()
-        result = []
-        if len(demo_teams) == 0:
-            return {"demo_users": []}
+    demo_teams = session.exec(select(Team).where(Team.is_demo == True)).all()
+    result = []
+    if len(demo_teams) == 0:
+        return {"demo_users": []}
 
-        for team in demo_teams:
-            latest_submission = session.exec(
-                select(Submission)
-                .where(Submission.team_id == team.id)
-                .order_by(Submission.timestamp.desc())
-            ).first()
-            # Add a null check before accessing .timestamp
-            latest_submission_timestamp = None
-            if latest_submission is not None:
-                latest_submission_timestamp = latest_submission.timestamp
-            # get the email from the DemoUser table
-            matching_demo_user = session.exec(
-                select(DemoUser).where(DemoUser.username == team.school_name)
-            ).first()  # for the special case of demo users, the username they typed in is saved as the school_name
-            email = matching_demo_user.email if matching_demo_user is not None else None
-            result.append(
-                {
-                    "demo_team_id": team.id,
-                    "demo_team_name": team.name,
-                    "email": email,
-                    "league_name": team.league.name if team.league else None,
-                    "number_of_submissions": len(team.submissions),
-                    "latest_submission": latest_submission_timestamp,
-                }
-            )
-        return {"demo_users": result}
-
-    except Exception as e:
-        session.rollback()
-        raise
+    for team in demo_teams:
+        latest_submission = session.exec(
+            select(Submission)
+            .where(Submission.team_id == team.id)
+            .order_by(Submission.timestamp.desc())
+        ).first()
+        # Add a null check before accessing .timestamp
+        latest_submission_timestamp = None
+        if latest_submission is not None:
+            latest_submission_timestamp = latest_submission.timestamp
+        # get the email from the DemoUser table
+        matching_demo_user = session.exec(
+            select(DemoUser).where(DemoUser.username == team.school_name)
+        ).first()  # for the special case of demo users, the username they typed in is saved as the school_name
+        email = matching_demo_user.email if matching_demo_user is not None else None
+        result.append(
+            {
+                "demo_team_id": team.id,
+                "demo_team_name": team.name,
+                "email": email,
+                "league_name": team.league.name if team.league else None,
+                "number_of_submissions": len(team.submissions),
+                "latest_submission": latest_submission_timestamp,
+            }
+        )
+    return {"demo_users": result}
 
 
 def delete_all_demo_teams_and_subs(session):
@@ -296,52 +271,42 @@ def delete_all_demo_teams_and_subs(session):
 # Agent team management functions
 def create_agent_team(session: Session, team_data: CreateAgentTeam) -> Dict:
     """Create a new agent team"""
-    try:
-        # Check if league exists and is agent type
-        league = session.get(League, team_data.league_id)
-        if not league:
-            raise ValueError(f"League with ID {team_data.league_id} not found")
-        if league.league_type != LeagueType.AGENT:
-            raise ValueError("Can only create agent teams in agent leagues")
+    # Check if league exists and is agent type
+    league = session.get(League, team_data.league_id)
+    if not league:
+        raise ValueError(f"League with ID {team_data.league_id} not found")
+    if league.league_type != LeagueType.AGENT:
+        raise ValueError("Can only create agent teams in agent leagues")
 
-        # Create team
-        team = Team(
-            name=team_data.name,
-            school_name="AI Agent",
-            team_type=TeamType.AGENT,
-            league_id=team_data.league_id,
-            institution_id=league.institution_id,  # Set the institution_id from the league
-        )
-        session.add(team)
-        session.commit()
-        session.refresh(team)
+    # Create team
+    team = Team(
+        name=team_data.name,
+        school_name="AI Agent",
+        team_type=TeamType.AGENT,
+        league_id=team_data.league_id,
+        institution_id=league.institution_id,
+    )
+    session.add(team)
+    session.commit()
+    session.refresh(team)
 
-        return {"team_id": team.id, "name": team.name, "league": league.name}
-
-    except Exception as e:
-        session.rollback()
-        raise
+    return {"team_id": team.id, "name": team.name, "league": league.name}
 
 
 def create_api_key(session: Session, team_id: int) -> Dict:
     """Create a new API key for an agent team"""
-    try:
-        team = session.get(Team, team_id)
-        if not team:
-            raise ValueError(f"Team with ID {team_id} not found")
-        if team.team_type != TeamType.AGENT:
-            raise ValueError("Can only create API keys for agent teams")
+    team = session.get(Team, team_id)
+    if not team:
+        raise ValueError(f"Team with ID {team_id} not found")
+    if team.team_type != TeamType.AGENT:
+        raise ValueError("Can only create API keys for agent teams")
 
-        # Generate secure API key
-        api_key = secrets.token_urlsafe(32)
+    # Generate secure API key
+    api_key = secrets.token_urlsafe(32)
 
-        # Create API key record
-        key_record = AgentAPIKey(key=api_key, team_id=team_id)
-        session.add(key_record)
-        session.commit()
+    # Create API key record
+    key_record = AgentAPIKey(key=api_key, team_id=team_id)
+    session.add(key_record)
+    session.commit()
 
-        return {"team_id": team_id, "api_key": api_key}
-
-    except Exception as e:
-        session.rollback()
-        raise
+    return {"team_id": team_id, "api_key": api_key}

--- a/backend/routes/admin/admin_models.py
+++ b/backend/routes/admin/admin_models.py
@@ -62,6 +62,12 @@ class CreateAgentTeam(BaseModel):
         return v.strip()
 
 
+class RestoreBackup(BaseModel):
+    """Model for restoring a database backup"""
+
+    s3_key: str
+
+
 class CreateAgentAPIKey(BaseModel):
     """Model for creating an API key"""
 

--- a/backend/routes/admin/admin_router.py
+++ b/backend/routes/admin/admin_router.py
@@ -6,6 +6,7 @@ from sqlmodel import Session
 
 from backend.config import get_service_url
 from backend.models_api import ErrorResponseModel, ResponseModel
+from backend.routes.admin.admin_backup import create_backup, list_backups, restore_backup
 from backend.routes.admin.admin_db import (
     create_agent_team,
     create_api_key,
@@ -23,6 +24,7 @@ from backend.routes.admin.admin_models import (
     CreateInstitution,
     DeleteInstitution,
     InstitutionUpdate,
+    RestoreBackup,
     ToggleDockerAccess,
 )
 from backend.routes.auth.auth_core import get_current_user, verify_admin_role
@@ -205,4 +207,66 @@ async def delete_all_demo_teams_and_submissions(
     except Exception as e:
         return ErrorResponseModel(
             status="error", message=f"Failed to delete demo users: {str(e)}"
+        )
+
+
+# Database backup endpoints
+@admin_router.post("/backup-database", response_model=ResponseModel)
+@verify_admin_role
+async def backup_database_endpoint(
+    current_user: dict = Depends(get_current_user),
+):
+    """Create a pg_dump backup and upload to DigitalOcean Spaces"""
+    try:
+        result = create_backup()
+        return ResponseModel(
+            status="success",
+            message=f"Backup created: {result['filename']}",
+            data=result,
+        )
+    except Exception as e:
+        logger.error(f"Error creating backup: {e}")
+        return ErrorResponseModel(
+            status="error", message=f"Backup failed: {str(e)}"
+        )
+
+
+@admin_router.get("/list-backups", response_model=ResponseModel)
+@verify_admin_role
+async def list_backups_endpoint(
+    current_user: dict = Depends(get_current_user),
+):
+    """List all database backups in DigitalOcean Spaces"""
+    try:
+        backups = list_backups()
+        return ResponseModel(
+            status="success",
+            message=f"Found {len(backups)} backup(s)",
+            data={"backups": backups},
+        )
+    except Exception as e:
+        logger.error(f"Error listing backups: {e}")
+        return ErrorResponseModel(
+            status="error", message=f"Failed to list backups: {str(e)}"
+        )
+
+
+@admin_router.post("/restore-database", response_model=ResponseModel)
+@verify_admin_role
+async def restore_database_endpoint(
+    request: RestoreBackup,
+    current_user: dict = Depends(get_current_user),
+):
+    """Restore the database from an S3 backup"""
+    try:
+        result = restore_backup(request.s3_key)
+        return ResponseModel(
+            status="success",
+            message=f"Database restored from {result['filename']}",
+            data=result,
+        )
+    except Exception as e:
+        logger.error(f"Error restoring backup: {e}")
+        return ErrorResponseModel(
+            status="error", message=f"Restore failed: {str(e)}"
         )

--- a/backend/routes/auth/auth_db.py
+++ b/backend/routes/auth/auth_db.py
@@ -123,45 +123,40 @@ def get_institution_token(session: Session, institution_name: str, password: str
 
 def verify_agent_api_key(session: Session, api_key: str):
     """Verify agent API key and return token"""
-    try:
-        # Find the API key record
-        api_key_record = session.exec(
-            select(AgentAPIKey).where(
-                AgentAPIKey.key == api_key, AgentAPIKey.is_active == True
-            )
-        ).one_or_none()
+    # Find the API key record
+    api_key_record = session.exec(
+        select(AgentAPIKey).where(
+            AgentAPIKey.key == api_key, AgentAPIKey.is_active == True
+        )
+    ).one_or_none()
 
-        if not api_key_record:
-            raise InvalidCredentialsError("Invalid or inactive API key")
+    if not api_key_record:
+        raise InvalidCredentialsError("Invalid or inactive API key")
 
-        # Get associated team
-        team = api_key_record.team
-        if not team or team.team_type != TeamType.AGENT:
-            raise InvalidCredentialsError(
-                "API key not associated with a valid agent team"
-            )
-
-        # Update last used timestamp
-        api_key_record.last_used = datetime.now(AUSTRALIA_SYDNEY_TZ)
-        session.commit()
-
-        # Create token data with institution_id if present
-        token_data = {
-            "sub": team.name,
-            "role": "ai_agent",
-            "team_name": team.name,
-        }
-
-        if team.institution_id:
-            token_data["institution_id"] = team.institution_id
-
-        access_token = create_access_token(
-            data=token_data,
-            expires_delta=timedelta(days=AGENT_TOKEN_EXPIRY_DAYS),
+    # Get associated team
+    team = api_key_record.team
+    if not team or team.team_type != TeamType.AGENT:
+        raise InvalidCredentialsError(
+            "API key not associated with a valid agent team"
         )
 
-        return {"access_token": access_token, "token_type": "bearer"}
+    # Update last used timestamp
+    api_key_record.last_used = datetime.now(AUSTRALIA_SYDNEY_TZ)
+    session.commit()
 
-    except Exception as e:
-        logger.error(f"Error verifying agent API key: {str(e)}")
-        raise InvalidCredentialsError("Error verifying API key")
+    # Create token data with institution_id if present
+    token_data = {
+        "sub": team.name,
+        "role": "ai_agent",
+        "team_name": team.name,
+    }
+
+    if team.institution_id:
+        token_data["institution_id"] = team.institution_id
+
+    access_token = create_access_token(
+        data=token_data,
+        expires_delta=timedelta(days=AGENT_TOKEN_EXPIRY_DAYS),
+    )
+
+    return {"access_token": access_token, "token_type": "bearer"}

--- a/backend/routes/auth/auth_db.py
+++ b/backend/routes/auth/auth_db.py
@@ -32,6 +32,16 @@ class RateLimitExceededError(Exception):
 AUSTRALIA_SYDNEY_TZ = pytz.timezone("Australia/Sydney")
 
 
+def get_institution_names(session: Session):
+    """Get list of active institution names for the login selector"""
+    institutions = session.exec(
+        select(Institution)
+        .where(Institution.subscription_active == True)
+        .where(Institution.name != "Demo Institution")
+    ).all()
+    return [inst.name for inst in institutions]
+
+
 def get_team_token(session: Session, team_name: str, team_password: str):
     """Get authentication token for team login"""
     team = session.exec(select(Team).where(Team.name == team_name)).one_or_none()

--- a/backend/routes/auth/auth_router.py
+++ b/backend/routes/auth/auth_router.py
@@ -9,6 +9,7 @@ from backend.routes.auth.auth_db import (
     InvalidCredentialsError,
     get_admin_token,
     get_institution_token,
+    get_institution_names,
     get_team_token,
     verify_agent_api_key,
 )
@@ -22,6 +23,19 @@ from backend.routes.auth.auth_models import (
 logger = logging.getLogger(__name__)
 
 auth_router = APIRouter()
+
+
+@auth_router.get("/institutions", response_model=ResponseModel)
+def list_institutions(session: Session = Depends(get_db)):
+    """
+    Public endpoint to list institution names for the login selector
+    """
+    try:
+        names = get_institution_names(session)
+        return ResponseModel(status="success", message="Institutions retrieved", data={"institutions": names})
+    except Exception as e:
+        logger.error(f"Error listing institutions: {str(e)}")
+        return ResponseModel(status="failed", message="Failed to retrieve institutions")
 
 
 @auth_router.post("/admin-login", response_model=ResponseModel)

--- a/backend/routes/institution/institution_db.py
+++ b/backend/routes/institution/institution_db.py
@@ -52,55 +52,45 @@ def create_league(session: Session, league_data, institution_id: int) -> Dict:
             f"League with name '{league_data['name']}' already exists for this institution"
         )
 
-    try:
-        # Validate game name
-        GameFactory.get_game_class(league_data["game"])
+    # Validate game name
+    GameFactory.get_game_class(league_data["game"])
 
-        # Generate unique signup token
-        signup_token = secrets.token_urlsafe(16)
+    # Generate unique signup token
+    signup_token = secrets.token_urlsafe(16)
 
-        # Create the league
-        league = League(
-            name=league_data["name"],
-            created_date=datetime.now(AUSTRALIA_SYDNEY_TZ),
-            expiry_date=(
-                datetime.now(AUSTRALIA_SYDNEY_TZ) + timedelta(hours=24)
-            ),  # Default 24 hour expiry
-            game=league_data["game"],
-            institution_id=institution_id,
-            league_type=LeagueType.INSTITUTION,
-            signup_link=signup_token,
-        )
+    # Create the league
+    league = League(
+        name=league_data["name"],
+        created_date=datetime.now(AUSTRALIA_SYDNEY_TZ),
+        expiry_date=(
+            datetime.now(AUSTRALIA_SYDNEY_TZ) + timedelta(hours=24)
+        ),  # Default 24 hour expiry
+        game=league_data["game"],
+        institution_id=institution_id,
+        league_type=LeagueType.INSTITUTION,
+        signup_link=signup_token,
+    )
 
-        session.add(league)
-        session.flush()
-        session.commit()
-        return {
-            "league_id": league.id,
-            "name": league.name,
-            "signup_token": signup_token,
-        }
-
-    except Exception as e:
-        session.rollback()
-        logger.error(f"Error creating league: {e}")
-        raise
+    session.add(league)
+    session.flush()
+    session.commit()
+    return {
+        "league_id": league.id,
+        "name": league.name,
+        "signup_token": signup_token,
+    }
 
 
 def create_team(session: Session, team_data, institution_id: int) -> Dict:
     """Create a new team for an institution"""
     try:
-        # Validate team data
-        if not team_data.name or not team_data.password:
-            raise TeamError("Team name and password are required")
-
         # Check for existing team within this institution
         existing_team = session.exec(
             select(Team)
             .where(Team.name == team_data.name)
             .where(Team.institution_id == institution_id)
         ).first()
-        
+
         if existing_team:
             raise TeamError(f"Team with name '{team_data.name}' already exists in this institution")
 
@@ -110,7 +100,7 @@ def create_team(session: Session, team_data, institution_id: int) -> Dict:
             .where(League.name == "unassigned")
             .where(League.institution_id == institution_id)
         ).first()
-        
+
         if not unassigned_league:
             # Create an unassigned league for this institution if it doesn't exist
             unassigned_league = League(
@@ -142,17 +132,13 @@ def create_team(session: Session, team_data, institution_id: int) -> Dict:
 
         return {"team_id": team.id, "name": team.name, "school": team.school_name}
 
-    except TeamError as e:
+    except TeamError:
         session.rollback()
         raise
     except IntegrityError as e:
         session.rollback()
         logger.error(f"Database integrity error creating team: {e}")
         raise TeamError("Unable to create team due to data constraints")
-    except Exception as e:
-        session.rollback()
-        logger.error(f"Unexpected error creating team: {e}")
-        raise TeamError(f"An unexpected error occurred creating the team: {str(e)}")
 
 
 def delete_team(session: Session, team_id: int, institution_id: int) -> str:
@@ -166,45 +152,36 @@ def delete_team(session: Session, team_id: int, institution_id: int) -> str:
     if team.institution_id != institution_id:
         raise InstitutionAccessError("You don't have permission to delete this team")
 
-    try:
-        # Delete associated submissions first
-        session.exec(delete(Submission).where(Submission.team_id == team.id))
+    # Delete associated submissions first
+    session.exec(delete(Submission).where(Submission.team_id == team.id))
 
-        # Delete all result items
-        session.exec(
-            delete(SimulationResultItem).where(SimulationResultItem.team_id == team_id)
-        )
+    # Delete all result items
+    session.exec(
+        delete(SimulationResultItem).where(SimulationResultItem.team_id == team_id)
+    )
 
-        session.delete(team)
-        session.commit()
+    session.delete(team)
+    session.commit()
 
-        return f"Team {team.name} deleted successfully"
-    except Exception as e:
-        session.rollback()
-        logger.error(f"Error deleting team: {e}")
-        raise
+    return f"Team {team.name} deleted successfully"
 
 
 def get_all_teams(session: Session, institution_id: int) -> Dict:
     """Get all teams for an institution"""
-    try:
-        teams = session.exec(
-            select(Team).where(Team.institution_id == institution_id)
-        ).all()
-        return {
-            "teams": [
-                {
-                    "id": team.id,
-                    "name": team.name,
-                    "school": team.school_name,
-                    "league": team.league.name if team.league else None,
-                }
-                for team in teams
-            ]
-        }
-    except Exception as e:
-        logger.error(f"Error retrieving teams: {e}")
-        raise
+    teams = session.exec(
+        select(Team).where(Team.institution_id == institution_id)
+    ).all()
+    return {
+        "teams": [
+            {
+                "id": team.id,
+                "name": team.name,
+                "school": team.school_name,
+                "league": team.league.name if team.league else None,
+            }
+            for team in teams
+        ]
+    }
 
 
 def get_league_by_id(session: Session, league_id: int, institution_id: int, is_admin: bool = False) -> League:
@@ -284,17 +261,12 @@ def get_all_league_results(session: Session, league_name: str, institution_id: i
     if not league:
         raise LeagueNotFoundError(f"League '{league_name}' not found in your institution")
 
-    try:
-        results = []
-        for sim in league.simulation_results:
-            result = process_simulation_results(sim, league_name)
-            results.append(result)
+    results = []
+    for sim in league.simulation_results:
+        result = process_simulation_results(sim, league_name)
+        results.append(result)
 
-        return {"results": sorted(results, key=lambda x: x["id"], reverse=True)}
-
-    except Exception as e:
-        logger.error(f"Error retrieving league results: {e}")
-        raise
+    return {"results": sorted(results, key=lambda x: x["id"], reverse=True)}
 
 
 def publish_sim_results(
@@ -325,39 +297,33 @@ def publish_sim_results(
     if simulation.league_id != league.id:
         raise InstitutionAccessError("You don't have permission to publish this simulation result")
 
-    try:
-        # Generate a unique publish link if not already set
-        if not simulation.publish_link:
-            simulation.publish_link = secrets.token_urlsafe(16)
+    # Generate a unique publish link if not already set
+    if not simulation.publish_link:
+        simulation.publish_link = secrets.token_urlsafe(16)
 
-        # Set the simulation as published
-        simulation.published = True
+    # Set the simulation as published
+    simulation.published = True
 
-        if feedback is not None:
-            if isinstance(feedback, str):
-                simulation.feedback_str = feedback
-                simulation.feedback_json = None
-            else:
-                simulation.feedback_str = None
-                simulation.feedback_json = json.dumps(feedback)
+    if feedback is not None:
+        if isinstance(feedback, str):
+            simulation.feedback_str = feedback
+            simulation.feedback_json = None
+        else:
+            simulation.feedback_str = None
+            simulation.feedback_json = json.dumps(feedback)
 
-        session.add(simulation)
-        session.commit()
+    session.add(simulation)
+    session.commit()
 
-        return (
-            f"Results published successfully for league '{league_name}'",
-            {
-                "sim_id": simulation.id,
-                "league_name": league_name,
-                "published": True,
-                "publish_link": simulation.publish_link,
-            },
-        )
-
-    except Exception as e:
-        session.rollback()
-        logger.error(f"Error publishing results: {e}")
-        raise
+    return (
+        f"Results published successfully for league '{league_name}'",
+        {
+            "sim_id": simulation.id,
+            "league_name": league_name,
+            "published": True,
+            "publish_link": simulation.publish_link,
+        },
+    )
 
 
 def update_expiry_date(
@@ -372,16 +338,10 @@ def update_expiry_date(
     if not league:
         raise LeagueNotFoundError(f"League '{league_name}' not found in your institution")
 
-    try:
-        league.expiry_date = expiry_date
-        session.add(league)
-        session.commit()
-        return f"Expiry date updated successfully for league '{league_name}'"
-
-    except Exception as e:
-        session.rollback()
-        logger.error(f"Error updating expiry date: {e}")
-        raise
+    league.expiry_date = expiry_date
+    session.add(league)
+    session.commit()
+    return f"Expiry date updated successfully for league '{league_name}'"
 
 
 def assign_team_to_league(session: Session, team_id: int, league_id: int, institution_id: int, is_admin: bool = False) -> str:
@@ -402,32 +362,20 @@ def assign_team_to_league(session: Session, team_id: int, league_id: int, instit
     if not is_admin and league.institution_id != institution_id:
         raise InstitutionAccessError("You don't have permission to assign teams to this league")
 
-    try:
-        team.league_id = league.id
-        session.add(team)
-        session.commit()
-        return f"Team '{team.name}' assigned to league '{league.name}'"
-    except Exception as e:
-        session.rollback()
-        logger.error(f"Error assigning team to league: {e}")
-        raise
+    team.league_id = league.id
+    session.add(team)
+    session.commit()
+    return f"Team '{team.name}' assigned to league '{league.name}'"
 
 
 def get_unassigned_league(session: Session, institution_id: int) -> League:
-    """Fetch the 'unassigned' league for an institution, creating it if missing."""
-    try:
-        unassigned_league = session.exec(
-            select(League)
-            .where(League.name == "unassigned")
-            .where(League.institution_id == institution_id)
-        ).first()
-
-        session.add(unassigned_league)
-        session.flush()
-        return unassigned_league
-    except Exception as e:
-        logger.error(f"Error fetching unassigned league: {e}")
-        raise
+    """Fetch the 'unassigned' league for an institution."""
+    unassigned_league = session.exec(
+        select(League)
+        .where(League.name == "unassigned")
+        .where(League.institution_id == institution_id)
+    ).first()
+    return unassigned_league
 
 
 def unassign_team(session: Session, team_id: int, institution_id: int) -> str:
@@ -439,46 +387,32 @@ def unassign_team(session: Session, team_id: int, institution_id: int) -> str:
     if team.institution_id != institution_id:
         raise InstitutionAccessError("You don't have permission to modify this team")
 
-    try:
-        unassigned_league = get_unassigned_league(session, institution_id)
-        team.league_id = unassigned_league.id
-        session.add(team)
-        session.commit()
-        return f"Team '{team.name}' moved to 'unassigned'"
-    except Exception as e:
-        session.rollback()
-        logger.error(f"Error unassigning team: {e}")
-        raise
+    unassigned_league = get_unassigned_league(session, institution_id)
+    team.league_id = unassigned_league.id
+    session.add(team)
+    session.commit()
+    return f"Team '{team.name}' moved to 'unassigned'"
 
 
 def generate_signup_link(session: Session, league_id: int, institution_id: int, is_admin: bool = False) -> Dict:
     """Generate a new signup link for a league"""
-    try:
-        # Get the league
-        league = session.get(League, league_id)
-        if not league:
-            raise LeagueNotFoundError(f"League with ID {league_id} not found")
+    league = session.get(League, league_id)
+    if not league:
+        raise LeagueNotFoundError(f"League with ID {league_id} not found")
 
-        # Check if the league belongs to this institution (admin bypasses)
-        if not is_admin and league.institution_id != institution_id:
-            raise InstitutionAccessError(
-                "You don't have permission to access this league"
-            )
+    # Check if the league belongs to this institution (admin bypasses)
+    if not is_admin and league.institution_id != institution_id:
+        raise InstitutionAccessError(
+            "You don't have permission to access this league"
+        )
 
-        # Generate a new signup token
-        signup_token = secrets.token_urlsafe(16)
-        league.signup_link = signup_token
-        session.add(league)
-        session.commit()
+    # Generate a new signup token
+    signup_token = secrets.token_urlsafe(16)
+    league.signup_link = signup_token
+    session.add(league)
+    session.commit()
 
-        return {"signup_token": signup_token, "league_name": league.name}
-    except (LeagueNotFoundError, InstitutionAccessError) as e:
-        # Re-raise these specific exceptions to be caught by the router
-        raise
-    except Exception as e:
-        session.rollback()
-        logger.error(f"Error generating signup link: {e}")
-        raise
+    return {"signup_token": signup_token, "league_name": league.name}
 
 
 def delete_league(session: Session, league_name: str, institution_id: int, is_admin: bool = False) -> str:
@@ -519,43 +453,37 @@ def delete_league(session: Session, league_name: str, institution_id: int, is_ad
         session.add(unassigned_league)
         session.flush()  # Get the ID for the new league
 
-    try:
-        # Get all teams in the league
-        teams = session.exec(select(Team).where(Team.league_id == league.id)).all()
-        team_count = len(teams)
+    # Get all teams in the league
+    teams = session.exec(select(Team).where(Team.league_id == league.id)).all()
+    team_count = len(teams)
 
-        # Get simulation results for this league
-        sim_results = session.exec(
-            select(SimulationResult).where(SimulationResult.league_id == league.id)
-        ).all()
-        # Delete all simulation result items for simulation results in this league
-        for sim_result in sim_results:
-            session.exec(
-                delete(SimulationResultItem).where(
-                    SimulationResultItem.simulation_result_id == sim_result.id
-                )
-            )
-
+    # Get simulation results for this league
+    sim_results = session.exec(
+        select(SimulationResult).where(SimulationResult.league_id == league.id)
+    ).all()
+    # Delete all simulation result items for simulation results in this league
+    for sim_result in sim_results:
         session.exec(
-            delete(SimulationResult).where(SimulationResult.league_id == league.id)
+            delete(SimulationResultItem).where(
+                SimulationResultItem.simulation_result_id == sim_result.id
+            )
         )
-        # Delete all submissions from teams in this league and move teams to unassigned league
-        for team in teams:
-            # Delete team's submissions
-            session.exec(delete(Submission).where(Submission.team_id == team.id))
 
-            # Move team to unassigned league
-            team.league_id = unassigned_league.id
-            session.add(team)
+    session.exec(
+        delete(SimulationResult).where(SimulationResult.league_id == league.id)
+    )
+    # Delete all submissions from teams in this league and move teams to unassigned league
+    for team in teams:
+        # Delete team's submissions
+        session.exec(delete(Submission).where(Submission.team_id == team.id))
 
-        session.commit()
-        # Delete the league
-        session.delete(league)
-        session.commit()
+        # Move team to unassigned league
+        team.league_id = unassigned_league.id
+        session.add(team)
 
-        return f"League '{league_name}' deleted and {team_count} teams moved to the unassigned league"
+    session.commit()
+    # Delete the league
+    session.delete(league)
+    session.commit()
 
-    except Exception as e:
-        session.rollback()
-        logger.error(f"Error deleting league: {e}")
-        raise
+    return f"League '{league_name}' deleted and {team_count} teams moved to the unassigned league"

--- a/backend/routes/institution/institution_db.py
+++ b/backend/routes/institution/institution_db.py
@@ -207,32 +207,33 @@ def get_all_teams(session: Session, institution_id: int) -> Dict:
         raise
 
 
-def get_league_by_id(session: Session, league_id: int, institution_id: int) -> League:
-    """Get a league by ID, ensuring it belongs to the institution"""
+def get_league_by_id(session: Session, league_id: int, institution_id: int, is_admin: bool = False) -> League:
+    """Get a league by ID, ensuring it belongs to the institution (admin bypasses ownership check)"""
     league = session.exec(select(League).where(League.id == league_id)).first()
-    
+
     if not league:
         raise LeagueNotFoundError(f"League with ID {league_id} not found")
-    
-    # Verify the league belongs to this institution
-    if league.institution_id != institution_id:
+
+    # Admin/Admin Institution can access any league
+    if not is_admin and league.institution_id != institution_id:
         raise InstitutionAccessError("You don't have permission to access this league")
-    
+
     return league
 
 
 def save_simulation_results(
-    session: Session, 
-    league_id: int, 
+    session: Session,
+    league_id: int,
     institution_id: int,
-    results: Dict, 
-    rewards=None, 
-    feedback_str=None, 
-    feedback_json=None
+    results: Dict,
+    rewards=None,
+    feedback_str=None,
+    feedback_json=None,
+    is_admin: bool = False,
 ) -> SimulationResult:
     """Save simulation results for a league"""
     # Verify the league belongs to this institution
-    league = get_league_by_id(session, league_id, institution_id)
+    league = get_league_by_id(session, league_id, institution_id, is_admin=is_admin)
     
     timestamp = datetime.now(AUSTRALIA_SYDNEY_TZ)
     rewards_str = rewards if rewards is not None else "[10, 8, 6, 4, 3, 2, 1]"
@@ -254,7 +255,7 @@ def save_simulation_results(
 
     for team_name, score in results["total_points"].items():
         team = session.exec(select(Team).where(Team.name == team_name)).one_or_none()
-        if team and team.institution_id == institution_id:  # Only include teams from this institution
+        if team and (is_admin or team.institution_id == institution_id):  # Only include teams from this institution
             result_item = SimulationResultItem(
                 simulation_result_id=simulation_result.id, team_id=team.id, score=score
             )
@@ -273,13 +274,12 @@ def save_simulation_results(
     return simulation_result
 
 
-def get_all_league_results(session: Session, league_name: str, institution_id: int) -> Dict:
+def get_all_league_results(session: Session, league_name: str, institution_id: int, is_admin: bool = False) -> Dict:
     """Get all simulation results for a league"""
-    league = session.exec(
-        select(League)
-        .where(League.name == league_name)
-        .where(League.institution_id == institution_id)
-    ).first()
+    query = select(League).where(League.name == league_name)
+    if not is_admin:
+        query = query.where(League.institution_id == institution_id)
+    league = session.exec(query).first()
 
     if not league:
         raise LeagueNotFoundError(f"League '{league_name}' not found in your institution")
@@ -303,13 +303,13 @@ def publish_sim_results(
     sim_id: int,
     institution_id: int,
     feedback: Union[str, Dict, None] = None,
+    is_admin: bool = False,
 ) -> Tuple[str, Dict]:
     """Publish simulation results"""
-    league = session.exec(
-        select(League)
-        .where(League.name == league_name)
-        .where(League.institution_id == institution_id)
-    ).first()
+    query = select(League).where(League.name == league_name)
+    if not is_admin:
+        query = query.where(League.institution_id == institution_id)
+    league = session.exec(query).first()
 
     if not league:
         raise LeagueNotFoundError(f"League '{league_name}' not found in your institution")
@@ -361,14 +361,13 @@ def publish_sim_results(
 
 
 def update_expiry_date(
-    session: Session, league_name: str, expiry_date: datetime, institution_id: int
+    session: Session, league_name: str, expiry_date: datetime, institution_id: int, is_admin: bool = False
 ) -> str:
     """Update league expiry date"""
-    league = session.exec(
-        select(League)
-        .where(League.name == league_name)
-        .where(League.institution_id == institution_id)
-    ).first()
+    query = select(League).where(League.name == league_name)
+    if not is_admin:
+        query = query.where(League.institution_id == institution_id)
+    league = session.exec(query).first()
 
     if not league:
         raise LeagueNotFoundError(f"League '{league_name}' not found in your institution")
@@ -385,22 +384,22 @@ def update_expiry_date(
         raise
 
 
-def assign_team_to_league(session: Session, team_id: int, league_id: int, institution_id: int) -> str:
+def assign_team_to_league(session: Session, team_id: int, league_id: int, institution_id: int, is_admin: bool = False) -> str:
     """Assign a team to a league within the same institution"""
     team = session.get(Team, team_id)
     if not team:
         raise TeamError(f"Team with ID {team_id} not found")
 
-    # Verify the team belongs to this institution
-    if team.institution_id != institution_id:
+    # Verify the team belongs to this institution (admin bypasses)
+    if not is_admin and team.institution_id != institution_id:
         raise InstitutionAccessError("You don't have permission to modify this team")
 
     league = session.get(League, league_id)
     if not league:
         raise LeagueNotFoundError(f"League with ID {league_id} not found")
 
-    # Verify the league belongs to this institution
-    if league.institution_id != institution_id:
+    # Verify the league belongs to this institution (admin bypasses)
+    if not is_admin and league.institution_id != institution_id:
         raise InstitutionAccessError("You don't have permission to assign teams to this league")
 
     try:
@@ -452,7 +451,7 @@ def unassign_team(session: Session, team_id: int, institution_id: int) -> str:
         raise
 
 
-def generate_signup_link(session: Session, league_id: int, institution_id: int) -> Dict:
+def generate_signup_link(session: Session, league_id: int, institution_id: int, is_admin: bool = False) -> Dict:
     """Generate a new signup link for a league"""
     try:
         # Get the league
@@ -460,8 +459,8 @@ def generate_signup_link(session: Session, league_id: int, institution_id: int) 
         if not league:
             raise LeagueNotFoundError(f"League with ID {league_id} not found")
 
-        # Check if the league belongs to this institution
-        if league.institution_id != institution_id:
+        # Check if the league belongs to this institution (admin bypasses)
+        if not is_admin and league.institution_id != institution_id:
             raise InstitutionAccessError(
                 "You don't have permission to access this league"
             )
@@ -482,14 +481,13 @@ def generate_signup_link(session: Session, league_id: int, institution_id: int) 
         raise
 
 
-def delete_league(session: Session, league_name: str, institution_id: int) -> str:
+def delete_league(session: Session, league_name: str, institution_id: int, is_admin: bool = False) -> str:
     """Delete a league and move its teams to the unassigned league"""
     # Find the league to delete
-    league = session.exec(
-        select(League)
-        .where(League.name == league_name)
-        .where(League.institution_id == institution_id)
-    ).first()
+    query = select(League).where(League.name == league_name)
+    if not is_admin:
+        query = query.where(League.institution_id == institution_id)
+    league = session.exec(query).first()
     if not league:
         raise LeagueNotFoundError(
             f"League '{league_name}' not found in your institution"

--- a/backend/routes/institution/institution_router.py
+++ b/backend/routes/institution/institution_router.py
@@ -59,6 +59,16 @@ class InstitutionAccessError(Exception):
     pass
 
 
+def _resolve_institution(current_user: dict) -> tuple[int, bool]:
+    """Extract institution_id and is_admin from the current user token.
+    Admin role falls back to institution_id=1. Admin Institution (id=1) is also treated as admin."""
+    if current_user["role"] == "admin":
+        return 1, True
+    institution_id = current_user.get("institution_id")
+    is_admin = institution_id == 1
+    return institution_id, is_admin
+
+
 @institution_router.post("/league-create", response_model=ResponseModel)
 @verify_admin_or_institution
 async def create_league_endpoint(
@@ -68,7 +78,7 @@ async def create_league_endpoint(
 ):
     """Create a new league for the institution"""
     try:
-        institution_id = current_user.get("institution_id")
+        institution_id, is_admin = _resolve_institution(current_user)
         if not institution_id:
             return ErrorResponseModel(
                 status="error", message="Institution ID not found in token"
@@ -144,10 +154,7 @@ async def get_teams_endpoint(
 ):
     """Get all teams for the institution"""
     try:
-        if current_user["role"] == "admin":
-            institution_id = 1
-        else:
-            institution_id = current_user.get("institution_id")
+        institution_id, is_admin = _resolve_institution(current_user)
         if not institution_id:
             return ErrorResponseModel(
                 status="error", message="Institution ID not found in token"
@@ -173,20 +180,19 @@ async def run_simulation_endpoint(
 ):
     """Run a simulation for a league owned by the institution"""
     try:
-        if current_user["role"] == "admin":
-            institution_id = 1
-        else:
-            institution_id = current_user.get("institution_id")
+        institution_id, is_admin = _resolve_institution(current_user)
         if not institution_id:
             return ErrorResponseModel(
                 status="error", message="Institution ID not found in token"
             )
 
-        # Get the league using the ID
-        league = get_league_by_id(session, simulation_config.league_id, institution_id)
+        # Get the league using the ID (admin bypasses ownership check)
+        league = get_league_by_id(session, simulation_config.league_id, institution_id, is_admin=is_admin)
 
         # Check if institution has Docker access
-        institution = session.get(Institution, institution_id)
+        # For admin managing another institution's league, check the league's owning institution
+        check_institution_id = league.institution_id if is_admin else institution_id
+        institution = session.get(Institution, check_institution_id)
         if not institution.docker_access:
             return ErrorResponseModel(
                 status="error",
@@ -235,6 +241,7 @@ async def run_simulation_endpoint(
                         feedback_json=(
                             json.dumps(feedback) if isinstance(feedback, dict) else None
                         ),
+                        is_admin=is_admin,
                     )
                 except Exception as e:
                     logger.error(f"Error saving simulation results: {str(e)}")
@@ -281,22 +288,19 @@ async def run_simulation_endpoint(
 @institution_router.post("/get-all-league-results", response_model=ResponseModel)
 @verify_admin_or_institution
 async def get_league_results_endpoint(
-    league: LeagueName,  # Change from LeagueSignUp to LeagueName
+    league: LeagueName,
     current_user: dict = Depends(get_current_user),
     session: Session = Depends(get_db),
 ):
     """Get all results for a specific league owned by the institution"""
     try:
-        if current_user["role"] == "admin":
-            institution_id = 1
-        else:
-            institution_id = current_user.get("institution_id")
+        institution_id, is_admin = _resolve_institution(current_user)
         if not institution_id:
             return ErrorResponseModel(
                 status="error", message="Institution ID not found in token"
             )
 
-        results = get_all_league_results(session, league.name, institution_id)
+        results = get_all_league_results(session, league.name, institution_id, is_admin=is_admin)
         return ResponseModel(
             status="success",
             message="League results retrieved successfully",
@@ -318,14 +322,15 @@ async def publish_results_endpoint(
 ):
     """Publish simulation results for a league owned by the institution"""
     try:
-        institution_id = current_user.get("institution_id")
+        institution_id, is_admin = _resolve_institution(current_user)
         if not institution_id:
             return ErrorResponseModel(
                 status="error", message="Institution ID not found in token"
             )
 
         msg, data = publish_sim_results(
-            session, results.league_name, results.id, institution_id, results.feedback
+            session, results.league_name, results.id, institution_id, results.feedback,
+            is_admin=is_admin,
         )
         return ResponseModel(status="success", message=msg, data=data)
     except Exception as e:
@@ -344,16 +349,13 @@ async def update_expiry_endpoint(
 ):
     """Update league expiry date for a league owned by the institution"""
     try:
-        if current_user["role"] == "admin":
-            institution_id = 1
-        else:
-            institution_id = current_user.get("institution_id")
+        institution_id, is_admin = _resolve_institution(current_user)
         if not institution_id:
             return ErrorResponseModel(
                 status="error", message="Institution ID not found in token"
             )
 
-        msg = update_expiry_date(session, expiry.league, expiry.date, institution_id)
+        msg = update_expiry_date(session, expiry.league, expiry.date, institution_id, is_admin=is_admin)
         return ResponseModel(status="success", message=msg)
     except Exception as e:
         logger.error(f"Error updating expiry date: {e}")
@@ -371,14 +373,15 @@ async def assign_team_endpoint(
 ):
     """Assign a team to a league within the institution"""
     try:
-        institution_id = current_user.get("institution_id")
+        institution_id, is_admin = _resolve_institution(current_user)
         if not institution_id:
             return ErrorResponseModel(
                 status="error", message="Institution ID not found in token"
             )
 
         msg = assign_team_to_league(
-            session, assignment.team_id, assignment.league_id, institution_id
+            session, assignment.team_id, assignment.league_id, institution_id,
+            is_admin=is_admin,
         )
         return ResponseModel(status="success", message=msg)
     except Exception as e:
@@ -397,12 +400,7 @@ async def generate_signup_link_endpoint(
 ):
     """Generate a signup link for a league"""
     try:
-        # Handle both admin and institution roles
-        if current_user["role"] == "admin":
-            institution_id = 1
-        else:
-            institution_id = current_user.get("institution_id")
-
+        institution_id, is_admin = _resolve_institution(current_user)
         if not institution_id:
             return ErrorResponseModel(
                 status="error", message="Institution ID not found in token"
@@ -423,7 +421,7 @@ async def generate_signup_link_endpoint(
             )
 
         try:
-            result = generate_signup_link(session, league_id, institution_id)
+            result = generate_signup_link(session, league_id, institution_id, is_admin=is_admin)
             return ResponseModel(
                 status="success",
                 message=f"Signup link generated for league {result['league_name']}",
@@ -460,13 +458,13 @@ async def delete_league_endpoint(
 ):
     """Delete a league and move all teams to the unassigned league"""
     try:
-        institution_id = current_user.get("institution_id")
+        institution_id, is_admin = _resolve_institution(current_user)
         if not institution_id:
             return ErrorResponseModel(
                 status="error", message="Institution ID not found in token"
             )
 
-        msg = delete_league(session, league.name, institution_id)
+        msg = delete_league(session, league.name, institution_id, is_admin=is_admin)
         return ResponseModel(status="success", message=msg)
     except Exception as e:
         logger.error(f"Error deleting league: {e}")
@@ -484,11 +482,7 @@ async def unassign_team_endpoint(
 ):
     """Move a team to the institution's 'unassigned' league without relying on client-provided league id."""
     try:
-        # Determine institution scope
-        if current_user["role"] == "admin":
-            institution_id = 1
-        else:
-            institution_id = current_user.get("institution_id")
+        institution_id, is_admin = _resolve_institution(current_user)
         if not institution_id:
             return ErrorResponseModel(
                 status="error", message="Institution ID not found in token"

--- a/backend/routes/user/user_db.py
+++ b/backend/routes/user/user_db.py
@@ -185,7 +185,34 @@ def get_all_leagues(session: Session):
                 "game": league.game,
                 "created_date": league.created_date,
                 "expiry_date": league.expiry_date,
-                "signup_link": league.signup_link,  # Make sure to include this
+                "signup_link": league.signup_link,
+            }
+            for league in leagues
+        ]
+    }
+
+
+def get_leagues_for_user(session: Session, role: str, institution_id: Optional[int]):
+    """Get leagues scoped to the user's institution. Admin and Admin Institution (id=1) see all."""
+    query = select(League).where(League.deleted_date == None)
+
+    if role != "admin" and institution_id != 1:
+        if institution_id is not None:
+            query = query.where(League.institution_id == institution_id)
+        else:
+            return {"leagues": []}
+
+    leagues = session.exec(query).all()
+
+    return {
+        "leagues": [
+            {
+                "id": league.id,
+                "name": league.name,
+                "game": league.game,
+                "created_date": league.created_date,
+                "expiry_date": league.expiry_date,
+                "signup_link": league.signup_link,
             }
             for league in leagues
         ]

--- a/backend/routes/user/user_db.py
+++ b/backend/routes/user/user_db.py
@@ -230,87 +230,69 @@ def get_latest_submissions_for_league(
     session: Session, league_id: int
 ) -> Dict[str, str]:
     """Get latest submissions for all teams in a league"""
-    try:
-        # First get all teams in the league
-        teams = session.exec(select(Team).where(Team.league_id == league_id)).all()
+    teams = session.exec(select(Team).where(Team.league_id == league_id)).all()
 
-        submissions = {}
-        for team in teams:
-            # Get latest submission for each team
-            latest_submission = session.exec(
-                select(Submission)
-                .where(Submission.team_id == team.id)
-                .order_by(Submission.timestamp.desc())
-                .limit(1)
-            ).first()
-
-            if latest_submission:
-                submissions[team.name] = latest_submission.code
-
-        logger.info(f"Found {len(submissions)} submissions for league {league_id}")
-        return submissions
-
-    except Exception as e:
-        logger.error(f"Error getting league submissions: {str(e)}")
-        raise
-
-
-def get_all_submissions_for_league(
-    session: Session, league_id: int
-) -> Dict[str, list]:
-    """Get all submissions for all teams in a league, ordered by timestamp"""
-    try:
-        teams = session.exec(select(Team).where(Team.league_id == league_id)).all()
-
-        result = {}
-        for team in teams:
-            submissions = session.exec(
-                select(Submission)
-                .where(Submission.team_id == team.id)
-                .order_by(Submission.timestamp.asc())
-            ).all()
-
-            result[team.name] = [
-                {
-                    "code": sub.code,
-                    "timestamp": sub.timestamp.isoformat(),
-                    "id": sub.id,
-                }
-                for sub in submissions
-            ]
-
-        logger.info(f"Found submissions for {len(result)} teams in league {league_id}")
-        return result
-
-    except Exception as e:
-        logger.error(f"Error getting all league submissions: {str(e)}")
-        raise
-
-
-def get_team_submission(session: Session, team_name: str) -> Dict[str, Optional[str]]:
-    """Get latest submission for a specific team"""
-    try:
-        # Get team first
-        team = session.exec(select(Team).where(Team.name == team_name)).first()
-
-        if not team:
-            logger.warning(f"Team not found: {team_name}")
-            return {"code": None}
-
-        # Get latest submission
-        submission = session.exec(
+    submissions = {}
+    for team in teams:
+        # Get latest submission for each team
+        latest_submission = session.exec(
             select(Submission)
             .where(Submission.team_id == team.id)
             .order_by(Submission.timestamp.desc())
             .limit(1)
         ).first()
 
-        # Return dictionary with code
-        return {"code": submission.code if submission else None}
+        if latest_submission:
+            submissions[team.name] = latest_submission.code
 
-    except Exception as e:
-        logger.error(f"Error getting team submission: {str(e)}")
-        raise
+    logger.info(f"Found {len(submissions)} submissions for league {league_id}")
+    return submissions
+
+
+def get_all_submissions_for_league(
+    session: Session, league_id: int
+) -> Dict[str, list]:
+    """Get all submissions for all teams in a league, ordered by timestamp"""
+    teams = session.exec(select(Team).where(Team.league_id == league_id)).all()
+
+    result = {}
+    for team in teams:
+        submissions = session.exec(
+            select(Submission)
+            .where(Submission.team_id == team.id)
+            .order_by(Submission.timestamp.asc())
+        ).all()
+
+        result[team.name] = [
+            {
+                "code": sub.code,
+                "timestamp": sub.timestamp.isoformat(),
+                "id": sub.id,
+            }
+            for sub in submissions
+        ]
+
+    logger.info(f"Found submissions for {len(result)} teams in league {league_id}")
+    return result
+
+
+def get_team_submission(session: Session, team_name: str) -> Dict[str, Optional[str]]:
+    """Get latest submission for a specific team"""
+    team = session.exec(select(Team).where(Team.name == team_name)).first()
+
+    if not team:
+        logger.warning(f"Team not found: {team_name}")
+        return {"code": None}
+
+    # Get latest submission
+    submission = session.exec(
+        select(Submission)
+        .where(Submission.team_id == team.id)
+        .order_by(Submission.timestamp.desc())
+        .limit(1)
+    ).first()
+
+    return {"code": submission.code if submission else None}
 
 
 def get_league_by_signup_token(session: Session, signup_token: str) -> League:

--- a/backend/routes/user/user_router.py
+++ b/backend/routes/user/user_router.py
@@ -25,6 +25,7 @@ from backend.routes.user.user_db import (
     assign_team_to_league,
     create_team_and_assign_to_league,
     get_all_leagues,
+    get_leagues_for_user,
     get_all_published_results,
     get_all_submissions_for_league,
     get_latest_submissions_for_league,
@@ -254,8 +255,12 @@ async def get_leagues_endpoint(
     logger.info(f"Current user data: {current_user}")
 
     try:
-        # Reuse existing admin function
-        leagues = get_all_leagues(session)
+        role = current_user.get("role")
+        institution_id = current_user.get("institution_id")
+        if role == "admin":
+            institution_id = 1
+
+        leagues = get_leagues_for_user(session, role, institution_id)
         return ResponseModel(
             status="success",
             message="Leagues retrieved successfully",

--- a/backend/tests/integration/routes/admin/test_admin_backup_routes.py
+++ b/backend/tests/integration/routes/admin/test_admin_backup_routes.py
@@ -1,0 +1,108 @@
+"""Integration tests for backup API endpoints — testing auth/routing with mocked backup functions."""
+
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+
+from backend.routes.auth.auth_core import create_access_token
+
+
+@pytest.fixture
+def admin_headers() -> dict:
+    token = create_access_token(
+        data={"sub": "admin", "role": "admin"},
+        expires_delta=timedelta(minutes=30),
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def student_headers() -> dict:
+    token = create_access_token(
+        data={"sub": "student", "role": "student"},
+        expires_delta=timedelta(minutes=30),
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+@patch("backend.routes.admin.admin_router.create_backup")
+def test_backup_database_success(mock_backup, client, admin_headers):
+    """Admin can trigger a backup."""
+    mock_backup.return_value = {
+        "filename": "agent_games_20260404.sql",
+        "s3_key": "backups/agent_games_20260404.sql",
+        "bucket": "agent-games-backups",
+        "size_bytes": 50000,
+        "timestamp": "20260404_120000",
+    }
+    resp = client.post("/admin/backup-database", headers=admin_headers)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "success"
+    assert resp.json()["data"]["filename"] == "agent_games_20260404.sql"
+    mock_backup.assert_called_once()
+
+
+def test_backup_database_no_auth(client):
+    """No token returns 401."""
+    resp = client.post("/admin/backup-database")
+    assert resp.status_code == 401
+
+
+def test_backup_database_wrong_role(client, student_headers):
+    """Non-admin role returns 403."""
+    resp = client.post("/admin/backup-database", headers=student_headers)
+    assert resp.status_code == 403
+
+
+@patch("backend.routes.admin.admin_router.list_backups")
+def test_list_backups_success(mock_list, client, admin_headers):
+    """Admin can list backups."""
+    mock_list.return_value = [
+        {
+            "filename": "agent_games_20260404.sql",
+            "s3_key": "backups/agent_games_20260404.sql",
+            "size_bytes": 50000,
+            "last_modified": "2026-04-04T12:00:00",
+        }
+    ]
+    resp = client.get("/admin/list-backups", headers=admin_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "success"
+    assert "1 backup" in data["message"]
+    assert len(data["data"]["backups"]) == 1
+    mock_list.assert_called_once()
+
+
+def test_list_backups_wrong_role(client, student_headers):
+    """Non-admin role returns 403."""
+    resp = client.get("/admin/list-backups", headers=student_headers)
+    assert resp.status_code == 403
+
+
+@patch("backend.routes.admin.admin_router.restore_backup")
+def test_restore_database_success(mock_restore, client, admin_headers):
+    """Admin can trigger a restore."""
+    mock_restore.return_value = {
+        "filename": "agent_games_20260404.sql",
+        "s3_key": "backups/agent_games_20260404.sql",
+    }
+    resp = client.post(
+        "/admin/restore-database",
+        headers=admin_headers,
+        json={"s3_key": "backups/agent_games_20260404.sql"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "success"
+    mock_restore.assert_called_once_with("backups/agent_games_20260404.sql")
+
+
+def test_restore_database_wrong_role(client, student_headers):
+    """Non-admin role returns 403."""
+    resp = client.post(
+        "/admin/restore-database",
+        headers=student_headers,
+        json={"s3_key": "backups/test.sql"},
+    )
+    assert resp.status_code == 403

--- a/backend/tests/integration/routes/admin/test_agent_teams.py
+++ b/backend/tests/integration/routes/admin/test_agent_teams.py
@@ -1,0 +1,131 @@
+"""Tests for agent team management — create_agent_team and create_api_key in admin_db.py."""
+
+from datetime import datetime, timedelta
+
+import pytest
+from sqlmodel import Session, select
+
+from backend.database.db_models import (
+    AgentAPIKey,
+    Institution,
+    League,
+    LeagueType,
+    Team,
+    TeamType,
+)
+from backend.routes.admin.admin_db import create_agent_team, create_api_key
+from backend.routes.admin.admin_models import CreateAgentTeam
+
+
+@pytest.fixture
+def agent_league(db_session: Session) -> dict:
+    """Create an institution with an agent-type league."""
+    institution = db_session.exec(
+        select(Institution).where(Institution.name == "Admin Institution")
+    ).first()
+
+    league = League(
+        name="agent_test_league",
+        created_date=datetime.now(),
+        expiry_date=datetime.now() + timedelta(days=30),
+        game="greedy_pig",
+        league_type=LeagueType.AGENT,
+        institution_id=institution.id,
+    )
+    db_session.add(league)
+    db_session.commit()
+    db_session.refresh(league)
+
+    return {"institution": institution, "league": league}
+
+
+def test_create_agent_team_success(db_session, agent_league):
+    """Creates an agent team in an agent league."""
+    data = CreateAgentTeam(name="test_agent_team", league_id=agent_league["league"].id)
+    result = create_agent_team(db_session, data)
+
+    assert result["name"] == "test_agent_team"
+    assert result["league"] == "agent_test_league"
+    assert "team_id" in result
+
+    team = db_session.get(Team, result["team_id"])
+    assert team.team_type == TeamType.AGENT
+    assert team.institution_id == agent_league["institution"].id
+
+
+def test_create_agent_team_league_not_found(db_session):
+    """Raises ValueError for non-existent league."""
+    data = CreateAgentTeam(name="orphan_agent", league_id=99999)
+    with pytest.raises(ValueError, match="not found"):
+        create_agent_team(db_session, data)
+
+
+def test_create_agent_team_wrong_league_type(db_session):
+    """Raises ValueError when league is not an agent league."""
+    institution = db_session.exec(
+        select(Institution).where(Institution.name == "Admin Institution")
+    ).first()
+
+    student_league = League(
+        name="student_league_for_agent_test",
+        created_date=datetime.now(),
+        expiry_date=datetime.now() + timedelta(days=7),
+        game="greedy_pig",
+        league_type=LeagueType.STUDENT,
+        institution_id=institution.id,
+    )
+    db_session.add(student_league)
+    db_session.commit()
+    db_session.refresh(student_league)
+
+    data = CreateAgentTeam(name="bad_agent", league_id=student_league.id)
+    with pytest.raises(ValueError, match="agent leagues"):
+        create_agent_team(db_session, data)
+
+
+def test_create_api_key_success(db_session, agent_league):
+    """Creates an API key for an agent team."""
+    team_data = CreateAgentTeam(name="api_key_agent", league_id=agent_league["league"].id)
+    team_result = create_agent_team(db_session, team_data)
+
+    result = create_api_key(db_session, team_result["team_id"])
+    assert "api_key" in result
+    assert result["team_id"] == team_result["team_id"]
+    assert len(result["api_key"]) > 20
+
+    # Verify in DB
+    key_record = db_session.exec(
+        select(AgentAPIKey).where(AgentAPIKey.team_id == team_result["team_id"])
+    ).first()
+    assert key_record is not None
+
+
+def test_create_api_key_team_not_found(db_session):
+    """Raises ValueError for non-existent team."""
+    with pytest.raises(ValueError, match="not found"):
+        create_api_key(db_session, 99999)
+
+
+def test_create_api_key_non_agent_team(db_session):
+    """Raises ValueError when team is not an agent team."""
+    institution = db_session.exec(
+        select(Institution).where(Institution.name == "Admin Institution")
+    ).first()
+    unassigned = db_session.exec(
+        select(League).where(League.name == "unassigned").where(League.institution_id == institution.id)
+    ).first()
+
+    student_team = Team(
+        name="non_agent_team_for_key_test",
+        school_name="School",
+        password_hash="hash",
+        league_id=unassigned.id,
+        institution_id=institution.id,
+        team_type=TeamType.STUDENT,
+    )
+    db_session.add(student_team)
+    db_session.commit()
+    db_session.refresh(student_team)
+
+    with pytest.raises(ValueError, match="agent teams"):
+        create_api_key(db_session, student_team.id)

--- a/backend/tests/integration/routes/agent/test_agent_route.py
+++ b/backend/tests/integration/routes/agent/test_agent_route.py
@@ -263,7 +263,7 @@ def test_agent_api_key_validation(
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "failed"
-    assert "error" in data["message"].lower()
+    assert "invalid" in data["message"].lower()
 
     # Test case 3: Inactive API key
     setup_api_key.is_active = False
@@ -274,7 +274,7 @@ def test_agent_api_key_validation(
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "failed"
-    assert "error" in data["message"].lower()
+    assert "invalid" in data["message"].lower()
 
 
 def test_agent_rate_limiting(

--- a/backend/tests/integration/routes/auth/test_institutions_endpoint.py
+++ b/backend/tests/integration/routes/auth/test_institutions_endpoint.py
@@ -1,0 +1,98 @@
+"""Tests for GET /auth/institutions — public endpoint listing institution names."""
+
+from datetime import datetime, timedelta
+
+import pytest
+from sqlmodel import Session, select
+
+from backend.database.db_models import Institution
+
+
+@pytest.fixture
+def multiple_institutions(db_session: Session) -> dict:
+    """Create a mix of active, inactive, and demo institutions."""
+    now = datetime.now()
+
+    active = Institution(
+        name="Active School",
+        contact_person="Teacher",
+        contact_email="teacher@school.com",
+        created_date=now,
+        subscription_active=True,
+        subscription_expiry=now + timedelta(days=30),
+        docker_access=True,
+        password_hash="hash",
+    )
+    db_session.add(active)
+
+    inactive = Institution(
+        name="Inactive School",
+        contact_person="Old Teacher",
+        contact_email="old@school.com",
+        created_date=now,
+        subscription_active=False,
+        subscription_expiry=now - timedelta(days=30),
+        docker_access=True,
+        password_hash="hash",
+    )
+    db_session.add(inactive)
+
+    demo = Institution(
+        name="Demo Institution",
+        contact_person="Demo",
+        contact_email="demo@example.com",
+        created_date=now,
+        subscription_active=True,
+        subscription_expiry=now + timedelta(days=365),
+        docker_access=True,
+        password_hash="hash",
+    )
+    db_session.add(demo)
+
+    db_session.commit()
+    db_session.refresh(active)
+    db_session.refresh(inactive)
+    db_session.refresh(demo)
+
+    return {"active": active, "inactive": inactive, "demo": demo}
+
+
+def test_list_institutions_success(client, multiple_institutions):
+    """Public endpoint returns only active, non-demo institutions."""
+    resp = client.get("/auth/institutions")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "success"
+
+    names = data["data"]["institutions"]
+
+    # Active institution is included
+    assert "Active School" in names
+
+    # Inactive institution is excluded
+    assert "Inactive School" not in names
+
+    # Demo Institution is excluded
+    assert "Demo Institution" not in names
+
+    # Admin Institution (created by conftest) is included since it's active
+    assert "Admin Institution" in names
+
+
+def test_list_institutions_no_auth_required(client, multiple_institutions):
+    """Endpoint is public — no auth token needed."""
+    resp = client.get("/auth/institutions")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "success"
+
+
+def test_list_institutions_response_format(client, multiple_institutions):
+    """Response has the expected structure."""
+    resp = client.get("/auth/institutions")
+    data = resp.json()
+    assert "data" in data
+    assert "institutions" in data["data"]
+    assert isinstance(data["data"]["institutions"], list)
+    # All items are strings
+    for name in data["data"]["institutions"]:
+        assert isinstance(name, str)

--- a/backend/tests/integration/routes/demo/test_demo_cleanup.py
+++ b/backend/tests/integration/routes/demo/test_demo_cleanup.py
@@ -1,0 +1,166 @@
+"""Tests for demo cleanup functions and edge cases in demo_db.py."""
+
+from datetime import datetime, timedelta
+
+import pytest
+import pytz
+from sqlmodel import Session, select
+
+from backend.database.db_models import (
+    Institution,
+    League,
+    LeagueType,
+    Submission,
+    Team,
+    TeamType,
+    get_password_hash,
+)
+from backend.routes.demo.demo_db import (
+    assign_user_to_demo_league,
+    cleanup_expired_demo_users,
+    cleanup_old_demo_submissions,
+    get_or_create_demo_institution,
+)
+
+AUSTRALIA_SYDNEY_TZ = pytz.timezone("Australia/Sydney")
+
+
+@pytest.fixture
+def demo_setup(db_session: Session) -> dict:
+    """Create demo infrastructure: institution, league, demo team with submissions."""
+    now = datetime.now(AUSTRALIA_SYDNEY_TZ)
+
+    demo_inst = get_or_create_demo_institution(db_session)
+    db_session.commit()
+
+    # Ensure unassigned league exists
+    unassigned = db_session.exec(
+        select(League).where(League.name == "unassigned")
+    ).first()
+    if not unassigned:
+        unassigned = League(
+            name="unassigned",
+            created_date=now,
+            expiry_date=now + timedelta(days=365),
+            game="greedy_pig",
+            institution_id=demo_inst.id,
+            league_type=LeagueType.INSTITUTION,
+        )
+        db_session.add(unassigned)
+        db_session.commit()
+        db_session.refresh(unassigned)
+
+    demo_league = League(
+        name="greedy_pig_demo",
+        created_date=now,
+        expiry_date=now + timedelta(days=7),
+        game="greedy_pig",
+        league_type=LeagueType.STUDENT,
+        is_demo=True,
+        institution_id=demo_inst.id,
+    )
+    db_session.add(demo_league)
+    db_session.commit()
+    db_session.refresh(demo_league)
+
+    # Old demo team (created 2 hours ago)
+    old_team = Team(
+        name="old_demo_team_Demo",
+        school_name="old_demo",
+        team_type=TeamType.STUDENT,
+        is_demo=True,
+        league_id=demo_league.id,
+        created_at=now - timedelta(hours=2),
+        password_hash=get_password_hash("pass"),
+        institution_id=demo_inst.id,
+    )
+    db_session.add(old_team)
+    db_session.commit()
+    db_session.refresh(old_team)
+
+    # Old submission
+    old_sub = Submission(
+        code="# old submission",
+        timestamp=now - timedelta(hours=2),
+        team_id=old_team.id,
+    )
+    db_session.add(old_sub)
+
+    # Recent submission
+    recent_sub = Submission(
+        code="# recent submission",
+        timestamp=now - timedelta(minutes=5),
+        team_id=old_team.id,
+    )
+    db_session.add(recent_sub)
+    db_session.commit()
+
+    return {
+        "demo_inst": demo_inst,
+        "demo_league": demo_league,
+        "unassigned": unassigned,
+        "old_team": old_team,
+    }
+
+
+def test_cleanup_old_demo_submissions(db_session, demo_setup):
+    """Deletes submissions older than the cutoff, keeps recent ones."""
+    # Clean up submissions older than 60 minutes
+    count = cleanup_old_demo_submissions(db_session, age_minutes=60)
+    assert count >= 1
+
+    # Recent submission should still exist
+    remaining = db_session.exec(
+        select(Submission).where(Submission.team_id == demo_setup["old_team"].id)
+    ).all()
+    assert len(remaining) >= 1
+    assert any("recent" in s.code for s in remaining)
+
+
+def test_cleanup_old_demo_submissions_no_teams(db_session):
+    """Returns 0 when no demo teams exist (already cleaned up)."""
+    # Delete all demo teams first
+    demo_teams = db_session.exec(select(Team).where(Team.is_demo == True)).all()
+    for t in demo_teams:
+        db_session.exec(
+            Submission.__table__.delete().where(Submission.team_id == t.id)
+        )
+        db_session.delete(t)
+    db_session.commit()
+
+    count = cleanup_old_demo_submissions(db_session, age_minutes=1)
+    assert count == 0
+
+
+def test_cleanup_expired_demo_users(db_session, demo_setup):
+    """Deletes demo users older than the cutoff."""
+    count = cleanup_expired_demo_users(db_session, age_minutes=60)
+    assert count >= 1
+
+    # The old team should be gone
+    team = db_session.exec(
+        select(Team).where(Team.name == "old_demo_team_Demo")
+    ).first()
+    assert team is None
+
+
+def test_assign_user_to_demo_league_success(db_session, demo_setup):
+    """Assigns a demo user to a demo league."""
+    data = demo_setup
+    result = assign_user_to_demo_league(db_session, data["old_team"].id, data["demo_league"].id)
+    assert result is True
+
+    db_session.refresh(data["old_team"])
+    assert data["old_team"].league_id == data["demo_league"].id
+
+
+def test_assign_user_to_demo_league_user_not_found(db_session, demo_setup):
+    """Returns False when user doesn't exist."""
+    result = assign_user_to_demo_league(db_session, 99999, demo_setup["demo_league"].id)
+    assert result is False
+
+
+def test_assign_user_to_demo_league_league_not_found(db_session, demo_setup):
+    """Returns False when league doesn't exist."""
+    result = assign_user_to_demo_league(db_session, demo_setup["old_team"].id, 99999)
+    assert result is False

--- a/backend/tests/integration/routes/institution/test_delete_league.py
+++ b/backend/tests/integration/routes/institution/test_delete_league.py
@@ -232,3 +232,109 @@ def test_delete_league_failures(client, delete_league_setup, db_session):
         json={"name": league.name},
     )
     assert response.status_code == 403
+
+
+def test_delete_league_creates_unassigned_if_missing(client, db_session):
+    """When deleting a league, if 'unassigned' league doesn't exist, it gets auto-created."""
+    from backend.database.db_models import (
+        SimulationResult,
+        SimulationResultItem,
+        Submission,
+    )
+
+    # Create institution WITHOUT an unassigned league
+    inst = Institution(
+        name="no_unassigned_inst",
+        contact_person="Test",
+        contact_email="test@test.com",
+        created_date=datetime.now(),
+        subscription_active=True,
+        subscription_expiry=datetime.now() + timedelta(days=30),
+        docker_access=True,
+        password_hash="hash",
+    )
+    db_session.add(inst)
+    db_session.commit()
+    db_session.refresh(inst)
+
+    # Verify no unassigned league exists
+    unassigned = db_session.exec(
+        select(League)
+        .where(League.name == "unassigned")
+        .where(League.institution_id == inst.id)
+    ).first()
+    assert unassigned is None
+
+    # Create a league with a team and simulation results
+    league = League(
+        name="league_to_delete_no_unassigned",
+        created_date=datetime.now(),
+        expiry_date=datetime.now() + timedelta(days=7),
+        game="greedy_pig",
+        institution_id=inst.id,
+    )
+    db_session.add(league)
+    db_session.commit()
+    db_session.refresh(league)
+
+    team = Team(
+        name="team_in_no_unassigned",
+        school_name="School",
+        password_hash="hash",
+        league_id=league.id,
+        institution_id=inst.id,
+    )
+    db_session.add(team)
+    db_session.commit()
+    db_session.refresh(team)
+
+    # Add submission
+    db_session.add(Submission(code="# test", timestamp=datetime.now(), team_id=team.id))
+
+    # Add simulation result with items
+    sim = SimulationResult(
+        league_id=league.id,
+        timestamp=datetime.now(),
+        num_simulations=5,
+        custom_rewards="[10,8,6]",
+    )
+    db_session.add(sim)
+    db_session.commit()
+    db_session.refresh(sim)
+
+    db_session.add(SimulationResultItem(
+        simulation_result_id=sim.id, team_id=team.id, score=50
+    ))
+    db_session.commit()
+
+    token = create_access_token(
+        data={"sub": inst.name, "role": "institution", "institution_id": inst.id},
+        expires_delta=timedelta(minutes=30),
+    )
+
+    # Delete the league
+    resp = client.post(
+        "/institution/delete-league",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"name": "league_to_delete_no_unassigned"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "success"
+
+    # Verify unassigned league was auto-created
+    unassigned = db_session.exec(
+        select(League)
+        .where(League.name == "unassigned")
+        .where(League.institution_id == inst.id)
+    ).first()
+    assert unassigned is not None
+
+    # Team was moved to the new unassigned league
+    db_session.refresh(team)
+    assert team.league_id == unassigned.id
+
+    # Sim results and items were cleaned up
+    remaining_sim = db_session.exec(
+        select(SimulationResult).where(SimulationResult.league_id == league.id)
+    ).first()
+    assert remaining_sim is None

--- a/backend/tests/integration/routes/institution/test_league_permissions.py
+++ b/backend/tests/integration/routes/institution/test_league_permissions.py
@@ -1,0 +1,360 @@
+"""Tests for institution-scoped league visibility and admin super-access.
+
+Verifies that:
+- Regular institutions see only their own leagues
+- Admin role and Admin Institution (id=1) see all leagues
+- Admin can simulate/publish/delete any institution's leagues
+- Regular institutions cannot access other institutions' leagues
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+from sqlmodel import Session, select
+
+from backend.database.db_models import (
+    Institution,
+    League,
+    LeagueType,
+    SimulationResult,
+    SimulationResultItem,
+    Submission,
+    Team,
+    TeamType,
+)
+from backend.routes.auth.auth_core import create_access_token
+
+
+@pytest.fixture
+def two_institutions(db_session: Session) -> dict:
+    """Create two separate institutions, each with a league and teams."""
+    now = datetime.now()
+
+    # Get the Admin Institution (id=1, created by conftest)
+    admin_inst = db_session.exec(
+        select(Institution).where(Institution.name == "Admin Institution")
+    ).first()
+    assert admin_inst is not None
+
+    # Institution A
+    inst_a = Institution(
+        name="PermTest Institution A",
+        contact_person="Person A",
+        contact_email="a@example.com",
+        created_date=now,
+        subscription_active=True,
+        subscription_expiry=now + timedelta(days=30),
+        docker_access=True,
+        password_hash="hash_a",
+    )
+    db_session.add(inst_a)
+    db_session.commit()
+    db_session.refresh(inst_a)
+
+    # Institution B
+    inst_b = Institution(
+        name="PermTest Institution B",
+        contact_person="Person B",
+        contact_email="b@example.com",
+        created_date=now,
+        subscription_active=True,
+        subscription_expiry=now + timedelta(days=30),
+        docker_access=True,
+        password_hash="hash_b",
+    )
+    db_session.add(inst_b)
+    db_session.commit()
+    db_session.refresh(inst_b)
+
+    # Unassigned leagues
+    for inst in [inst_a, inst_b]:
+        db_session.add(League(
+            name="unassigned",
+            created_date=now,
+            expiry_date=now + timedelta(days=365),
+            game="greedy_pig",
+            league_type=LeagueType.INSTITUTION,
+            institution_id=inst.id,
+        ))
+    db_session.commit()
+
+    # League for A
+    league_a = League(
+        name="perm_league_a",
+        created_date=now,
+        expiry_date=now + timedelta(days=7),
+        game="prisoners_dilemma",
+        institution_id=inst_a.id,
+    )
+    db_session.add(league_a)
+    db_session.commit()
+    db_session.refresh(league_a)
+
+    # League for B
+    league_b = League(
+        name="perm_league_b",
+        created_date=now,
+        expiry_date=now + timedelta(days=7),
+        game="greedy_pig",
+        institution_id=inst_b.id,
+    )
+    db_session.add(league_b)
+    db_session.commit()
+    db_session.refresh(league_b)
+
+    # Teams + submissions for league A
+    for i in range(2):
+        team = Team(
+            name=f"perm_team_a_{i}",
+            school_name=f"School A{i}",
+            password_hash="hash",
+            league_id=league_a.id,
+            institution_id=inst_a.id,
+            team_type=TeamType.STUDENT,
+        )
+        db_session.add(team)
+        db_session.commit()
+        db_session.refresh(team)
+        db_session.add(Submission(
+            code='from games.prisoners_dilemma.player import Player\nclass CustomPlayer(Player):\n    def make_decision(self, game_state):\n        return "collude"',
+            timestamp=now,
+            team_id=team.id,
+        ))
+
+    # Teams + submissions for league B
+    for i in range(2):
+        team = Team(
+            name=f"perm_team_b_{i}",
+            school_name=f"School B{i}",
+            password_hash="hash",
+            league_id=league_b.id,
+            institution_id=inst_b.id,
+            team_type=TeamType.STUDENT,
+        )
+        db_session.add(team)
+        db_session.commit()
+        db_session.refresh(team)
+        db_session.add(Submission(
+            code='from games.greedy_pig.player import Player\nclass CustomPlayer(Player):\n    def make_decision(self, game_state):\n        if game_state["unbanked_money"][self.name] > 15:\n            return "bank"\n        return "continue"',
+            timestamp=now,
+            team_id=team.id,
+        ))
+
+    db_session.commit()
+
+    # Tokens
+    token_a = create_access_token(
+        data={"sub": inst_a.name, "role": "institution", "institution_id": inst_a.id},
+        expires_delta=timedelta(minutes=30),
+    )
+    token_b = create_access_token(
+        data={"sub": inst_b.name, "role": "institution", "institution_id": inst_b.id},
+        expires_delta=timedelta(minutes=30),
+    )
+    admin_token = create_access_token(
+        data={"sub": "admin", "role": "admin"},
+        expires_delta=timedelta(minutes=30),
+    )
+    admin_inst_token = create_access_token(
+        data={"sub": admin_inst.name, "role": "institution", "institution_id": admin_inst.id},
+        expires_delta=timedelta(minutes=30),
+    )
+    student_a_token = create_access_token(
+        data={"sub": "perm_team_a_0", "role": "student", "institution_id": inst_a.id},
+        expires_delta=timedelta(minutes=30),
+    )
+    student_no_inst_token = create_access_token(
+        data={"sub": "orphan_student", "role": "student"},
+        expires_delta=timedelta(minutes=30),
+    )
+
+    return {
+        "inst_a": inst_a,
+        "inst_b": inst_b,
+        "admin_inst": admin_inst,
+        "league_a": league_a,
+        "league_b": league_b,
+        "headers_a": {"Authorization": f"Bearer {token_a}"},
+        "headers_b": {"Authorization": f"Bearer {token_b}"},
+        "headers_admin": {"Authorization": f"Bearer {admin_token}"},
+        "headers_admin_inst": {"Authorization": f"Bearer {admin_inst_token}"},
+        "headers_student_a": {"Authorization": f"Bearer {student_a_token}"},
+        "headers_student_no_inst": {"Authorization": f"Bearer {student_no_inst_token}"},
+    }
+
+
+def test_get_all_leagues_scoped(client, two_institutions):
+    """Institutions see only their own leagues; admin sees all."""
+    data = two_institutions
+
+    # Institution A sees its leagues but not B's
+    resp = client.get("/user/get-all-leagues", headers=data["headers_a"])
+    assert resp.status_code == 200
+    names = [l["name"] for l in resp.json()["data"]["leagues"]]
+    assert "perm_league_a" in names
+    assert "perm_league_b" not in names
+
+    # Institution B sees its leagues but not A's
+    resp = client.get("/user/get-all-leagues", headers=data["headers_b"])
+    names = [l["name"] for l in resp.json()["data"]["leagues"]]
+    assert "perm_league_b" in names
+    assert "perm_league_a" not in names
+
+    # Admin role sees all
+    resp = client.get("/user/get-all-leagues", headers=data["headers_admin"])
+    names = [l["name"] for l in resp.json()["data"]["leagues"]]
+    assert "perm_league_a" in names
+    assert "perm_league_b" in names
+
+    # Admin Institution (id=1) sees all
+    resp = client.get("/user/get-all-leagues", headers=data["headers_admin_inst"])
+    names = [l["name"] for l in resp.json()["data"]["leagues"]]
+    assert "perm_league_a" in names
+    assert "perm_league_b" in names
+
+    # Student with institution_id sees only their institution's leagues
+    resp = client.get("/user/get-all-leagues", headers=data["headers_student_a"])
+    names = [l["name"] for l in resp.json()["data"]["leagues"]]
+    assert "perm_league_a" in names
+    assert "perm_league_b" not in names
+
+    # Student without institution_id gets empty list
+    resp = client.get("/user/get-all-leagues", headers=data["headers_student_no_inst"])
+    leagues = resp.json()["data"]["leagues"]
+    assert leagues == []
+
+
+def _mock_simulation_response(team_names):
+    """Helper to build a mock httpx response for simulation."""
+    mock_resp = type("MockResponse", (), {
+        "status_code": 200,
+        "json": lambda self: {
+            "status": "success",
+            "simulation_results": {
+                "total_points": {name: 100 for name in team_names},
+                "num_simulations": 10,
+                "table": {},
+            },
+            "feedback": "test",
+            "player_feedback": None,
+        },
+    })()
+
+    async def mock_post(*args, **kwargs):
+        return mock_resp
+
+    return mock_post
+
+
+def test_run_simulation_cross_institution(client, two_institutions):
+    """Institution A cannot simulate B's league; admin can simulate any."""
+    data = two_institutions
+    team_names_b = ["perm_team_b_0", "perm_team_b_1"]
+
+    with patch("httpx.AsyncClient.post") as mock_post:
+        mock_post.side_effect = _mock_simulation_response(team_names_b)
+
+        # Institution A CANNOT simulate B's league
+        resp = client.post(
+            "/institution/run-simulation",
+            headers=data["headers_a"],
+            json={"league_id": data["league_b"].id, "num_simulations": 10},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "error"
+        assert "permission" in resp.json()["message"].lower()
+
+        # Admin CAN simulate B's league
+        resp = client.post(
+            "/institution/run-simulation",
+            headers=data["headers_admin"],
+            json={"league_id": data["league_b"].id, "num_simulations": 10},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "success"
+
+        # Admin Institution CAN simulate B's league
+        resp = client.post(
+            "/institution/run-simulation",
+            headers=data["headers_admin_inst"],
+            json={"league_id": data["league_b"].id, "num_simulations": 10},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "success"
+
+
+def test_publish_results_cross_institution(client, two_institutions, db_session):
+    """Institution A cannot publish B's results; admin can."""
+    data = two_institutions
+
+    # Create a simulation result for league B
+    sim = SimulationResult(
+        league_id=data["league_b"].id,
+        timestamp=datetime.now(),
+        num_simulations=10,
+        custom_rewards="[10,8,6]",
+    )
+    db_session.add(sim)
+    db_session.commit()
+    db_session.refresh(sim)
+
+    # Institution A CANNOT publish B's results
+    resp = client.post(
+        "/institution/publish-results",
+        headers=data["headers_a"],
+        json={"league_name": "perm_league_b", "id": sim.id},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "error"
+
+    # Admin CAN publish B's results
+    resp = client.post(
+        "/institution/publish-results",
+        headers=data["headers_admin"],
+        json={"league_name": "perm_league_b", "id": sim.id},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "success"
+    assert resp.json()["data"]["published"] is True
+
+
+def test_delete_league_cross_institution(client, two_institutions, db_session):
+    """Institution A cannot delete B's league; admin can."""
+    data = two_institutions
+
+    # Create expendable leagues for deletion tests
+    now = datetime.now()
+    delete_target = League(
+        name="perm_delete_target",
+        created_date=now,
+        expiry_date=now + timedelta(days=7),
+        game="greedy_pig",
+        institution_id=data["inst_b"].id,
+    )
+    db_session.add(delete_target)
+    db_session.commit()
+
+    # Institution A CANNOT delete B's league
+    resp = client.post(
+        "/institution/delete-league",
+        headers=data["headers_a"],
+        json={"name": "perm_delete_target"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "error"
+
+    # Admin CAN delete B's league
+    resp = client.post(
+        "/institution/delete-league",
+        headers=data["headers_admin"],
+        json={"name": "perm_delete_target"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "success"
+
+    # Verify it's actually deleted
+    league = db_session.exec(
+        select(League).where(League.name == "perm_delete_target")
+    ).first()
+    assert league is None

--- a/backend/tests/integration/routes/institution/test_team_create.py
+++ b/backend/tests/integration/routes/institution/test_team_create.py
@@ -156,3 +156,48 @@ def test_team_create_failures(client, institution_setup, db_session):
         },
     )
     assert response.status_code == 403
+
+
+def test_team_create_global_duplicate(client, institution_setup, db_session):
+    """Team name that exists in another institution triggers IntegrityError → TeamError."""
+    institution, _, headers = institution_setup
+
+    # Create a team in this institution
+    response = client.post(
+        "/institution/team-create",
+        headers=headers,
+        json={"name": "globally_unique_team", "password": "pass", "school_name": "School A"},
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "success"
+
+    # Create another institution
+    other = Institution(
+        name="other_inst_for_dup_test",
+        contact_person="Other",
+        contact_email="other@test.com",
+        created_date=datetime.now(),
+        subscription_active=True,
+        subscription_expiry=datetime.now() + timedelta(days=30),
+        docker_access=True,
+        password_hash="hash",
+    )
+    db_session.add(other)
+    db_session.commit()
+    db_session.refresh(other)
+
+    other_token = create_access_token(
+        data={"sub": other.name, "role": "institution", "institution_id": other.id},
+        expires_delta=timedelta(minutes=30),
+    )
+
+    # Try creating team with same name in different institution — hits DB unique constraint
+    response = client.post(
+        "/institution/team-create",
+        headers={"Authorization": f"Bearer {other_token}"},
+        json={"name": "globally_unique_team", "password": "pass", "school_name": "School B"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "error"
+    assert "data constraints" in data["message"].lower() or "already exists" in data["message"].lower()

--- a/backend/tests/integration/routes/institution/test_unassign_team.py
+++ b/backend/tests/integration/routes/institution/test_unassign_team.py
@@ -1,0 +1,136 @@
+"""Tests for unassign-team and get_unassigned_league — covering previously uncovered paths."""
+
+from datetime import datetime, timedelta
+
+import pytest
+from sqlmodel import Session, select
+
+from backend.database.db_models import Institution, League, LeagueType, Team, TeamType
+from backend.routes.auth.auth_core import create_access_token
+
+
+@pytest.fixture
+def unassign_setup(db_session: Session) -> dict:
+    """Create institution with a league, unassigned league, and a team."""
+    now = datetime.now()
+
+    institution = Institution(
+        name="unassign_test_inst",
+        contact_person="Test",
+        contact_email="test@test.com",
+        created_date=now,
+        subscription_active=True,
+        subscription_expiry=now + timedelta(days=30),
+        docker_access=True,
+        password_hash="hash",
+    )
+    db_session.add(institution)
+    db_session.commit()
+    db_session.refresh(institution)
+
+    unassigned = League(
+        name="unassigned",
+        created_date=now,
+        expiry_date=now + timedelta(days=365),
+        game="greedy_pig",
+        institution_id=institution.id,
+        league_type=LeagueType.INSTITUTION,
+    )
+    db_session.add(unassigned)
+    db_session.commit()
+    db_session.refresh(unassigned)
+
+    league = League(
+        name="unassign_test_league",
+        created_date=now,
+        expiry_date=now + timedelta(days=7),
+        game="greedy_pig",
+        institution_id=institution.id,
+    )
+    db_session.add(league)
+    db_session.commit()
+    db_session.refresh(league)
+
+    team = Team(
+        name="unassign_test_team",
+        school_name="School",
+        password_hash="hash",
+        league_id=league.id,
+        institution_id=institution.id,
+        team_type=TeamType.STUDENT,
+    )
+    db_session.add(team)
+    db_session.commit()
+    db_session.refresh(team)
+
+    token = create_access_token(
+        data={"sub": institution.name, "role": "institution", "institution_id": institution.id},
+        expires_delta=timedelta(minutes=30),
+    )
+
+    return {
+        "institution": institution,
+        "league": league,
+        "unassigned": unassigned,
+        "team": team,
+        "headers": {"Authorization": f"Bearer {token}"},
+    }
+
+
+def test_unassign_team_success(client, unassign_setup, db_session):
+    """Unassign moves team to the unassigned league."""
+    data = unassign_setup
+
+    resp = client.post(
+        "/institution/unassign-team",
+        headers=data["headers"],
+        json={"team_id": data["team"].id},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "success"
+    assert "unassigned" in resp.json()["message"].lower()
+
+    # Verify in DB
+    db_session.refresh(data["team"])
+    assert data["team"].league_id == data["unassigned"].id
+
+
+def test_unassign_team_not_found(client, unassign_setup):
+    """Unassign non-existent team returns error."""
+    resp = client.post(
+        "/institution/unassign-team",
+        headers=unassign_setup["headers"],
+        json={"team_id": 99999},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "error"
+
+
+def test_unassign_team_wrong_institution(client, unassign_setup, db_session):
+    """Cannot unassign a team from another institution."""
+    other_inst = Institution(
+        name="other_unassign_inst",
+        contact_person="Other",
+        contact_email="other@test.com",
+        created_date=datetime.now(),
+        subscription_active=True,
+        subscription_expiry=datetime.now() + timedelta(days=30),
+        docker_access=True,
+        password_hash="hash",
+    )
+    db_session.add(other_inst)
+    db_session.commit()
+    db_session.refresh(other_inst)
+
+    other_token = create_access_token(
+        data={"sub": other_inst.name, "role": "institution", "institution_id": other_inst.id},
+        expires_delta=timedelta(minutes=30),
+    )
+
+    resp = client.post(
+        "/institution/unassign-team",
+        headers={"Authorization": f"Bearer {other_token}"},
+        json={"team_id": unassign_setup["team"].id},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "error"

--- a/backend/tests/integration/routes/user/test_all_league_submissions.py
+++ b/backend/tests/integration/routes/user/test_all_league_submissions.py
@@ -1,0 +1,152 @@
+"""Tests for GET /user/get-all-league-submissions/{league_id}."""
+
+from datetime import datetime, timedelta
+
+import pytest
+from sqlmodel import Session, select
+
+from backend.database.db_models import (
+    Institution,
+    League,
+    Submission,
+    Team,
+    TeamType,
+)
+from backend.routes.auth.auth_core import create_access_token
+
+
+@pytest.fixture
+def league_with_submissions(db_session: Session) -> dict:
+    """Create a league with 2 teams and multiple submissions each."""
+    institution = db_session.exec(
+        select(Institution).where(Institution.name == "Admin Institution")
+    ).first()
+
+    league = League(
+        name="submissions_test_league",
+        created_date=datetime.now(),
+        expiry_date=datetime.now() + timedelta(days=7),
+        game="greedy_pig",
+        institution_id=institution.id,
+    )
+    db_session.add(league)
+    db_session.commit()
+    db_session.refresh(league)
+
+    teams = []
+    for i in range(2):
+        team = Team(
+            name=f"sub_test_team_{i}",
+            school_name=f"Sub School {i}",
+            password_hash="hash",
+            league_id=league.id,
+            institution_id=institution.id,
+            team_type=TeamType.STUDENT,
+        )
+        db_session.add(team)
+        db_session.commit()
+        db_session.refresh(team)
+        teams.append(team)
+
+        # Add 3 submissions per team with ascending timestamps
+        base_time = datetime.now() - timedelta(hours=3)
+        for j in range(3):
+            db_session.add(Submission(
+                code=f"# submission {j} for team {i}",
+                timestamp=base_time + timedelta(hours=j),
+                team_id=team.id,
+            ))
+    db_session.commit()
+
+    # Empty league (no teams)
+    empty_league = League(
+        name="empty_submissions_league",
+        created_date=datetime.now(),
+        expiry_date=datetime.now() + timedelta(days=7),
+        game="greedy_pig",
+        institution_id=institution.id,
+    )
+    db_session.add(empty_league)
+    db_session.commit()
+    db_session.refresh(empty_league)
+
+    token = create_access_token(
+        data={"sub": "admin", "role": "admin"},
+        expires_delta=timedelta(minutes=30),
+    )
+
+    return {
+        "league": league,
+        "empty_league": empty_league,
+        "teams": teams,
+        "headers": {"Authorization": f"Bearer {token}"},
+    }
+
+
+def test_get_all_submissions_success(client, league_with_submissions):
+    """Returns all submissions for all teams with correct structure."""
+    data = league_with_submissions
+    resp = client.get(
+        f"/user/get-all-league-submissions/{data['league'].id}",
+        headers=data["headers"],
+    )
+    assert resp.status_code == 200
+    result = resp.json()
+    assert result["status"] == "success"
+
+    payload = result["data"]
+    assert payload["league_name"] == "submissions_test_league"
+
+    teams = payload["teams"]
+    assert "sub_test_team_0" in teams
+    assert "sub_test_team_1" in teams
+
+    # Each team has 3 submissions
+    for team_name in ["sub_test_team_0", "sub_test_team_1"]:
+        subs = teams[team_name]
+        assert len(subs) == 3
+
+        # Each submission has the required fields
+        for sub in subs:
+            assert "code" in sub
+            assert "timestamp" in sub
+            assert "id" in sub
+
+        # Submissions are ordered ascending by timestamp
+        timestamps = [s["timestamp"] for s in subs]
+        assert timestamps == sorted(timestamps)
+
+
+def test_get_all_submissions_empty_league(client, league_with_submissions):
+    """League with no teams returns empty teams dict."""
+    data = league_with_submissions
+    resp = client.get(
+        f"/user/get-all-league-submissions/{data['empty_league'].id}",
+        headers=data["headers"],
+    )
+    assert resp.status_code == 200
+    result = resp.json()
+    assert result["status"] == "success"
+    assert result["data"]["teams"] == {}
+    assert result["data"]["league_name"] == "empty_submissions_league"
+
+
+def test_get_all_submissions_no_auth(client, league_with_submissions):
+    """No auth token returns 401."""
+    resp = client.get(
+        f"/user/get-all-league-submissions/{league_with_submissions['league'].id}"
+    )
+    assert resp.status_code == 401
+
+
+def test_get_all_submissions_invalid_league(client, league_with_submissions):
+    """Non-existent league_id returns success with null league_name."""
+    resp = client.get(
+        "/user/get-all-league-submissions/99999",
+        headers=league_with_submissions["headers"],
+    )
+    assert resp.status_code == 200
+    result = resp.json()
+    assert result["status"] == "success"
+    assert result["data"]["league_name"] is None
+    assert result["data"]["teams"] == {}

--- a/backend/tests/integration/routes/user/test_direct_league_signup.py
+++ b/backend/tests/integration/routes/user/test_direct_league_signup.py
@@ -1,0 +1,212 @@
+"""Tests for POST /user/direct-league-signup — token-based team creation and auto-login."""
+
+import secrets
+from datetime import datetime, timedelta
+
+import pytest
+import pytz
+from jose import jwt
+from sqlmodel import Session, select
+
+from backend.database.db_models import Institution, League, LeagueType, Team
+from backend.routes.auth.auth_config import SECRET_KEY, ALGORITHM
+
+AUSTRALIA_SYDNEY_TZ = pytz.timezone("Australia/Sydney")
+
+
+@pytest.fixture
+def signup_league(db_session: Session) -> dict:
+    """Create an institution with a league that has a valid signup token."""
+    now = datetime.now(AUSTRALIA_SYDNEY_TZ)
+
+    institution = Institution(
+        name="Signup Test School",
+        contact_person="Teacher",
+        contact_email="teacher@signup.com",
+        created_date=now,
+        subscription_active=True,
+        subscription_expiry=now + timedelta(days=30),
+        docker_access=True,
+        password_hash="hash",
+    )
+    db_session.add(institution)
+    db_session.commit()
+    db_session.refresh(institution)
+
+    token = secrets.token_urlsafe(16)
+    league = League(
+        name="signup_test_league",
+        created_date=now,
+        expiry_date=now + timedelta(days=7),
+        game="greedy_pig",
+        institution_id=institution.id,
+        league_type=LeagueType.INSTITUTION,
+        signup_link=token,
+    )
+    db_session.add(league)
+    db_session.commit()
+    db_session.refresh(league)
+
+    return {"institution": institution, "league": league, "signup_token": token}
+
+
+@pytest.fixture
+def expired_league(db_session: Session) -> dict:
+    """Create a league with an expired date and signup token."""
+    now = datetime.now(AUSTRALIA_SYDNEY_TZ)
+
+    institution = db_session.exec(
+        select(Institution).where(Institution.name == "Admin Institution")
+    ).first()
+
+    token = secrets.token_urlsafe(16)
+    league = League(
+        name="expired_signup_league",
+        created_date=now - timedelta(days=14),
+        expiry_date=now - timedelta(days=1),
+        game="greedy_pig",
+        institution_id=institution.id,
+        league_type=LeagueType.INSTITUTION,
+        signup_link=token,
+    )
+    db_session.add(league)
+    db_session.commit()
+    db_session.refresh(league)
+
+    return {"league": league, "signup_token": token}
+
+
+def test_direct_signup_success(client, signup_league, db_session):
+    """Successful signup creates team, assigns to league, and returns a valid token."""
+    resp = client.post(
+        "/user/direct-league-signup",
+        json={
+            "team_name": "signup_team_1",
+            "password": "securepass123",
+            "signup_token": signup_league["signup_token"],
+            "school_name": "Test High School",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "success"
+    assert "created and assigned" in data["message"]
+
+    result = data["data"]
+    assert result["team_name"] == "signup_team_1"
+    assert result["league_name"] == "signup_test_league"
+    assert result["league_id"] == signup_league["league"].id
+    assert "access_token" in result
+
+    # Token is valid and decodable
+    decoded = jwt.decode(result["access_token"], SECRET_KEY, algorithms=[ALGORITHM])
+    assert decoded["sub"] == "signup_team_1"
+    assert decoded["role"] == "student"
+
+    # Team exists in DB linked to correct league and institution
+    team = db_session.exec(select(Team).where(Team.name == "signup_team_1")).first()
+    assert team is not None
+    assert team.league_id == signup_league["league"].id
+    assert team.institution_id == signup_league["institution"].id
+    assert team.school_name == "Test High School"
+
+
+def test_direct_signup_token_usable(client, signup_league):
+    """The returned token can be used to access authenticated endpoints."""
+    resp = client.post(
+        "/user/direct-league-signup",
+        json={
+            "team_name": "signup_token_test",
+            "password": "pass123",
+            "signup_token": signup_league["signup_token"],
+            "school_name": "",
+        },
+    )
+    token = resp.json()["data"]["access_token"]
+
+    # Use token to access an authenticated endpoint
+    resp = client.get(
+        "/user/get-all-leagues",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "success"
+
+
+def test_direct_signup_failures(client, signup_league, expired_league, db_session):
+    """Error cases for direct league signup."""
+    # Invalid signup token
+    resp = client.post(
+        "/user/direct-league-signup",
+        json={
+            "team_name": "fail_team",
+            "password": "pass123",
+            "signup_token": "nonexistent_token",
+            "school_name": "",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "error"
+    assert "not found" in resp.json()["message"].lower() or "signup" in resp.json()["message"].lower()
+
+    # Expired league
+    resp = client.post(
+        "/user/direct-league-signup",
+        json={
+            "team_name": "expired_team",
+            "password": "pass123",
+            "signup_token": expired_league["signup_token"],
+            "school_name": "",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "error"
+    assert "expired" in resp.json()["message"].lower()
+
+    # Duplicate team name — first create one successfully
+    client.post(
+        "/user/direct-league-signup",
+        json={
+            "team_name": "dup_team",
+            "password": "pass123",
+            "signup_token": signup_league["signup_token"],
+            "school_name": "",
+        },
+    )
+    # Try again with same name
+    resp = client.post(
+        "/user/direct-league-signup",
+        json={
+            "team_name": "dup_team",
+            "password": "pass456",
+            "signup_token": signup_league["signup_token"],
+            "school_name": "",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "error"
+    assert "already exists" in resp.json()["message"].lower()
+
+    # Empty team name
+    resp = client.post(
+        "/user/direct-league-signup",
+        json={
+            "team_name": "",
+            "password": "pass123",
+            "signup_token": signup_league["signup_token"],
+            "school_name": "",
+        },
+    )
+    assert resp.status_code == 422
+
+    # Empty password
+    resp = client.post(
+        "/user/direct-league-signup",
+        json={
+            "team_name": "empty_pass_team",
+            "password": "",
+            "signup_token": signup_league["signup_token"],
+            "school_name": "",
+        },
+    )
+    assert resp.status_code == 422

--- a/backend/tests/integration/routes/user/test_user_db_coverage.py
+++ b/backend/tests/integration/routes/user/test_user_db_coverage.py
@@ -1,0 +1,223 @@
+"""Tests covering uncovered paths in user_db.py:
+- allow_submission with non-existent team
+- assign_team_to_league with demo user / non-demo league
+- get_published_result with tz-naive dates and feedback_json
+- get_all_published_results
+- get_result_by_publish_link
+- create_team_and_assign_to_league with non-existent league
+"""
+
+import json
+import secrets
+from datetime import datetime, timedelta
+
+import pytest
+import pytz
+from sqlmodel import Session, select
+
+from backend.database.db_models import (
+    Institution,
+    League,
+    LeagueType,
+    SimulationResult,
+    SimulationResultItem,
+    Submission,
+    Team,
+    TeamType,
+)
+from backend.routes.auth.auth_core import create_access_token
+from backend.routes.user.user_db import (
+    TeamNotFoundError,
+    LeagueNotFoundError,
+    TeamError,
+    SubmissionLimitExceededError,
+    allow_submission,
+    assign_team_to_league,
+    get_published_result,
+    get_all_published_results,
+    create_team_and_assign_to_league,
+    get_result_by_publish_link,
+)
+
+AUSTRALIA_SYDNEY_TZ = pytz.timezone("Australia/Sydney")
+
+
+@pytest.fixture
+def published_league(db_session: Session) -> dict:
+    """Create a league with a published simulation result including custom values and feedback."""
+    institution = db_session.exec(
+        select(Institution).where(Institution.name == "Admin Institution")
+    ).first()
+
+    league = League(
+        name="published_test_league",
+        created_date=datetime.now(),  # tz-naive on purpose to test localization
+        expiry_date=datetime.now() + timedelta(days=7),  # tz-naive
+        game="greedy_pig",
+        institution_id=institution.id,
+    )
+    db_session.add(league)
+    db_session.commit()
+    db_session.refresh(league)
+
+    team = Team(
+        name="published_test_team",
+        school_name="School",
+        password_hash="hash",
+        league_id=league.id,
+        institution_id=institution.id,
+        team_type=TeamType.STUDENT,
+    )
+    db_session.add(team)
+    db_session.commit()
+    db_session.refresh(team)
+
+    publish_link = secrets.token_urlsafe(16)
+    sim = SimulationResult(
+        league_id=league.id,
+        timestamp=datetime.now(AUSTRALIA_SYDNEY_TZ),
+        num_simulations=10,
+        custom_rewards="[10, 8, 6]",
+        published=True,
+        publish_link=publish_link,
+        feedback_json=json.dumps({"round_1": "Player banked early"}),
+    )
+    db_session.add(sim)
+    db_session.commit()
+    db_session.refresh(sim)
+
+    result_item = SimulationResultItem(
+        simulation_result_id=sim.id,
+        team_id=team.id,
+        score=100,
+        custom_value1=5,
+        custom_value1_name="wins",
+    )
+    db_session.add(result_item)
+    db_session.commit()
+
+    return {
+        "league": league,
+        "team": team,
+        "sim": sim,
+        "publish_link": publish_link,
+        "institution": institution,
+    }
+
+
+def test_allow_submission_team_not_found(db_session):
+    """allow_submission raises TeamNotFoundError for non-existent team."""
+    with pytest.raises(TeamNotFoundError):
+        allow_submission(db_session, 99999)
+
+
+def test_assign_team_demo_to_non_demo_league(db_session):
+    """Demo team cannot be assigned to a non-demo league."""
+    institution = db_session.exec(
+        select(Institution).where(Institution.name == "Admin Institution")
+    ).first()
+
+    league = League(
+        name="non_demo_league_test",
+        created_date=datetime.now(),
+        expiry_date=datetime.now() + timedelta(days=7),
+        game="greedy_pig",
+        institution_id=institution.id,
+        is_demo=False,
+    )
+    db_session.add(league)
+    db_session.commit()
+
+    demo_team = Team(
+        name="demo_assign_test",
+        school_name="Demo",
+        password_hash="hash",
+        league_id=league.id,
+        institution_id=institution.id,
+        team_type=TeamType.STUDENT,
+        is_demo=True,
+    )
+    db_session.add(demo_team)
+    db_session.commit()
+
+    with pytest.raises(ValueError, match="Demo users can only join demo leagues"):
+        assign_team_to_league(db_session, "demo_assign_test", "non_demo_league_test")
+
+
+def test_assign_team_not_found(db_session):
+    """assign_team_to_league raises TeamNotFoundError for non-existent team."""
+    institution = db_session.exec(
+        select(Institution).where(Institution.name == "Admin Institution")
+    ).first()
+    league = League(
+        name="assign_target_league",
+        created_date=datetime.now(),
+        expiry_date=datetime.now() + timedelta(days=7),
+        game="greedy_pig",
+        institution_id=institution.id,
+    )
+    db_session.add(league)
+    db_session.commit()
+
+    with pytest.raises(TeamNotFoundError):
+        assign_team_to_league(db_session, "nonexistent_team_xyz", "assign_target_league")
+
+
+def test_get_published_result_with_feedback_json(db_session, published_league):
+    """get_published_result returns feedback from feedback_json when feedback_str is None."""
+    result = get_published_result(db_session, "published_test_league")
+    assert result is not None
+    assert result["league_name"] == "published_test_league"
+    assert result["num_simulations"] == 10
+    assert result["total_points"]["published_test_team"] == 100
+    # feedback_json was set, feedback_str was None
+    assert isinstance(result["feedback"], dict)
+    assert "round_1" in result["feedback"]
+    assert result["active"] is True
+
+
+def test_get_published_result_no_published(db_session):
+    """get_published_result returns None when no simulation is published."""
+    institution = db_session.exec(
+        select(Institution).where(Institution.name == "Admin Institution")
+    ).first()
+    league = League(
+        name="no_published_league",
+        created_date=datetime.now(),
+        expiry_date=datetime.now() + timedelta(days=7),
+        game="greedy_pig",
+        institution_id=institution.id,
+    )
+    db_session.add(league)
+    db_session.commit()
+
+    result = get_published_result(db_session, "no_published_league")
+    assert result is None
+
+
+def test_get_all_published_results(db_session, published_league):
+    """get_all_published_results includes published results across leagues."""
+    result = get_all_published_results(db_session)
+    assert "all_results" in result
+    # At least our published league should be in there
+    league_names = [r.get("league_name") for r in result["all_results"]]
+    assert "published_test_league" in league_names
+
+
+def test_get_result_by_publish_link(db_session, published_league):
+    """get_result_by_publish_link returns the correct published result."""
+    result = get_result_by_publish_link(db_session, published_league["publish_link"])
+    assert result["league_name"] == "published_test_league"
+    assert "total_points" in result
+
+
+def test_get_result_by_publish_link_not_found(db_session):
+    """get_result_by_publish_link raises ValueError for invalid link."""
+    with pytest.raises(ValueError, match="not found"):
+        get_result_by_publish_link(db_session, "nonexistent_link_abc")
+
+
+def test_create_team_and_assign_league_not_found(db_session):
+    """create_team_and_assign_to_league raises when league doesn't exist."""
+    with pytest.raises(LeagueNotFoundError):
+        create_team_and_assign_to_league(db_session, "new_team", "pass", 99999)

--- a/backend/tests/integration/routes/user/test_user_league.py
+++ b/backend/tests/integration/routes/user/test_user_league.py
@@ -3,13 +3,23 @@ from datetime import datetime, timedelta
 import pytest
 from sqlmodel import Session, select
 
-from backend.database.db_models import League, Team
+from backend.database.db_models import Institution, League, Team
 from backend.routes.auth.auth_core import create_access_token
 from backend.routes.user.user_db import get_team
 
 
 @pytest.fixture
-def setup_leagues(db_session: Session) -> dict:
+def test_institution(db_session: Session) -> Institution:
+    """Get the Admin Institution created by conftest seed data"""
+    institution = db_session.exec(
+        select(Institution).where(Institution.name == "Admin Institution")
+    ).first()
+    assert institution is not None, "Admin Institution not found"
+    return institution
+
+
+@pytest.fixture
+def setup_leagues(db_session: Session, test_institution: Institution) -> dict:
     """Create test leagues for assignment testing"""
     leagues = {}
 
@@ -24,6 +34,7 @@ def setup_leagues(db_session: Session) -> dict:
             created_date=datetime.now(),
             expiry_date=datetime.now() + timedelta(days=7),
             game="greedy_pig",
+            institution_id=test_institution.id,
         )
         db_session.add(comp_test)
         db_session.commit()
@@ -39,6 +50,7 @@ def setup_leagues(db_session: Session) -> dict:
             created_date=datetime.now(),
             expiry_date=datetime.now() + timedelta(days=7),
             game="prisoners_dilemma",
+            institution_id=test_institution.id,
         )
         db_session.add(pd_league)
         db_session.commit()
@@ -49,7 +61,7 @@ def setup_leagues(db_session: Session) -> dict:
 
 
 @pytest.fixture
-def setup_unassigned_team(db_session: Session) -> Team:
+def setup_unassigned_team(db_session: Session, test_institution: Institution) -> Team:
     """Create a test team in unassigned league"""
     # Get unassigned league
     unassigned = db_session.exec(
@@ -67,6 +79,7 @@ def setup_unassigned_team(db_session: Session) -> Team:
             school_name="Test School",
             password_hash="test_hash",
             league_id=unassigned.id,
+            institution_id=test_institution.id,
         )
         db_session.add(team)
         db_session.commit()
@@ -79,7 +92,11 @@ def setup_unassigned_team(db_session: Session) -> Team:
 def student_token(setup_unassigned_team: Team) -> str:
     """Create a valid student token for the test team"""
     return create_access_token(
-        data={"sub": setup_unassigned_team.name, "role": "student"},
+        data={
+            "sub": setup_unassigned_team.name,
+            "role": "student",
+            "institution_id": setup_unassigned_team.institution_id,
+        },
         expires_delta=timedelta(minutes=30),
     )
 

--- a/backend/tests/unit/routes/admin/test_admin_backup.py
+++ b/backend/tests/unit/routes/admin/test_admin_backup.py
@@ -1,0 +1,226 @@
+"""Unit tests for admin_backup.py — mocked S3 and subprocess calls."""
+
+import os
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import pytest
+from botocore.exceptions import ClientError
+
+
+# ─── _parse_db_url ────────────────────────────────────────────────────────────
+
+@patch("backend.routes.admin.admin_backup.get_database_url")
+def test_parse_db_url_standard(mock_url):
+    """Parses a standard postgresql+psycopg URL."""
+    mock_url.return_value = "postgresql+psycopg://myuser:mypass@dbhost:5433/mydb"
+    from backend.routes.admin.admin_backup import _parse_db_url
+
+    result = _parse_db_url()
+    assert result["host"] == "dbhost"
+    assert result["port"] == "5433"
+    assert result["user"] == "myuser"
+    assert result["password"] == "mypass"
+    assert result["dbname"] == "mydb"
+
+
+@patch("backend.routes.admin.admin_backup.get_database_url")
+def test_parse_db_url_defaults(mock_url):
+    """Falls back to defaults when components are missing."""
+    mock_url.return_value = "postgresql+psycopg:///testdb"
+    from backend.routes.admin.admin_backup import _parse_db_url
+
+    result = _parse_db_url()
+    assert result["host"] == "localhost"
+    assert result["port"] == "5432"
+    assert result["user"] == "postgres"
+    assert result["password"] == ""
+    assert result["dbname"] == "testdb"
+
+
+# ─── _get_s3_client ──────────────────────────────────────────────────────────
+
+def test_get_s3_client_missing_key():
+    """Raises ValueError when AWS_ACCESS_KEY_ID is missing."""
+    from backend.routes.admin.admin_backup import _get_s3_client
+
+    env = {k: v for k, v in os.environ.items() if k not in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY")}
+    with patch.dict(os.environ, env, clear=True):
+        with pytest.raises(ValueError, match="Missing AWS credentials"):
+            _get_s3_client()
+
+
+def test_get_s3_client_missing_secret():
+    """Raises ValueError when AWS_SECRET_ACCESS_KEY is missing."""
+    from backend.routes.admin.admin_backup import _get_s3_client
+
+    env = {"AWS_ACCESS_KEY_ID": "test_key"}
+    with patch.dict(os.environ, env, clear=True):
+        with pytest.raises(ValueError, match="Missing AWS credentials"):
+            _get_s3_client()
+
+
+# ─── create_backup ────────────────────────────────────────────────────────────
+
+@patch("backend.routes.admin.admin_backup._get_s3_client")
+@patch("backend.routes.admin.admin_backup.subprocess.run")
+@patch("backend.routes.admin.admin_backup._parse_db_url")
+def test_create_backup_success(mock_parse, mock_run, mock_s3):
+    """Successful backup: pg_dump + S3 upload."""
+    from backend.routes.admin.admin_backup import create_backup
+
+    mock_parse.return_value = {
+        "host": "localhost", "port": "5432",
+        "user": "postgres", "password": "pass", "dbname": "testdb",
+    }
+    mock_run.return_value = MagicMock(returncode=0, stderr="")
+    mock_s3.return_value = MagicMock()
+
+    # Patch os.path.getsize to return a fake size
+    with patch("backend.routes.admin.admin_backup.os.path.getsize", return_value=12345):
+        result = create_backup()
+
+    assert "filename" in result
+    assert result["filename"].startswith("agent_games_")
+    assert result["filename"].endswith(".sql")
+    assert result["s3_key"].startswith("backups/")
+    assert result["size_bytes"] == 12345
+    assert "timestamp" in result
+
+    # pg_dump was called
+    mock_run.assert_called_once()
+    args = mock_run.call_args
+    assert "pg_dump" in args[0][0]
+
+    # S3 upload was called
+    mock_s3.return_value.upload_file.assert_called_once()
+
+
+@patch("backend.routes.admin.admin_backup._parse_db_url")
+@patch("backend.routes.admin.admin_backup.subprocess.run")
+def test_create_backup_pgdump_fails(mock_run, mock_parse):
+    """RuntimeError when pg_dump returns non-zero."""
+    from backend.routes.admin.admin_backup import create_backup
+
+    mock_parse.return_value = {
+        "host": "localhost", "port": "5432",
+        "user": "postgres", "password": "", "dbname": "testdb",
+    }
+    mock_run.return_value = MagicMock(returncode=1, stderr="connection refused")
+
+    with pytest.raises(RuntimeError, match="pg_dump failed"):
+        create_backup()
+
+
+@patch("backend.routes.admin.admin_backup._get_s3_client")
+@patch("backend.routes.admin.admin_backup.subprocess.run")
+@patch("backend.routes.admin.admin_backup._parse_db_url")
+def test_create_backup_s3_upload_fails(mock_parse, mock_run, mock_s3):
+    """RuntimeError when S3 upload fails."""
+    from backend.routes.admin.admin_backup import create_backup
+
+    mock_parse.return_value = {
+        "host": "localhost", "port": "5432",
+        "user": "postgres", "password": "", "dbname": "testdb",
+    }
+    mock_run.return_value = MagicMock(returncode=0)
+    mock_s3.return_value.upload_file.side_effect = ClientError(
+        {"Error": {"Code": "AccessDenied", "Message": "denied"}}, "upload_file"
+    )
+
+    with patch("backend.routes.admin.admin_backup.os.path.getsize", return_value=100):
+        with pytest.raises(RuntimeError, match="Failed to upload to S3"):
+            create_backup()
+
+
+# ─── list_backups ─────────────────────────────────────────────────────────────
+
+@patch("backend.routes.admin.admin_backup._get_s3_client")
+def test_list_backups_success(mock_s3):
+    """Returns sorted list of backups, most recent first."""
+    from backend.routes.admin.admin_backup import list_backups
+    from datetime import datetime
+
+    mock_s3.return_value.list_objects_v2.return_value = {
+        "Contents": [
+            {
+                "Key": "backups/agent_games_20260101_000000.sql",
+                "Size": 1000,
+                "LastModified": datetime(2026, 1, 1),
+            },
+            {
+                "Key": "backups/agent_games_20260201_000000.sql",
+                "Size": 2000,
+                "LastModified": datetime(2026, 2, 1),
+            },
+        ]
+    }
+
+    result = list_backups()
+    assert len(result) == 2
+    # Most recent first
+    assert result[0]["filename"] == "agent_games_20260201_000000.sql"
+    assert result[1]["filename"] == "agent_games_20260101_000000.sql"
+    assert result[0]["size_bytes"] == 2000
+
+
+@patch("backend.routes.admin.admin_backup._get_s3_client")
+def test_list_backups_empty(mock_s3):
+    """Empty bucket returns empty list."""
+    from backend.routes.admin.admin_backup import list_backups
+
+    mock_s3.return_value.list_objects_v2.return_value = {}
+
+    result = list_backups()
+    assert result == []
+
+
+# ─── restore_backup ───────────────────────────────────────────────────────────
+
+@patch("backend.routes.admin.admin_backup._get_s3_client")
+@patch("backend.routes.admin.admin_backup.subprocess.run")
+@patch("backend.routes.admin.admin_backup._parse_db_url")
+def test_restore_backup_success(mock_parse, mock_run, mock_s3):
+    """Successful restore downloads, drops, creates, and restores."""
+    from backend.routes.admin.admin_backup import restore_backup
+
+    mock_parse.return_value = {
+        "host": "localhost", "port": "5432",
+        "user": "postgres", "password": "pass", "dbname": "testdb",
+    }
+    # All subprocess calls succeed
+    mock_run.return_value = MagicMock(returncode=0, stderr="")
+    mock_s3.return_value = MagicMock()
+
+    result = restore_backup("backups/agent_games_20260101_000000.sql")
+
+    assert result["filename"] == "agent_games_20260101_000000.sql"
+    assert result["s3_key"] == "backups/agent_games_20260101_000000.sql"
+
+    # S3 download was called
+    mock_s3.return_value.download_file.assert_called_once()
+
+    # subprocess.run called 4 times: terminate, drop, create, restore
+    assert mock_run.call_count == 4
+
+
+@patch("backend.routes.admin.admin_backup._get_s3_client")
+@patch("backend.routes.admin.admin_backup.subprocess.run")
+@patch("backend.routes.admin.admin_backup._parse_db_url")
+def test_restore_backup_drop_fails(mock_parse, mock_run, mock_s3):
+    """RuntimeError when DROP DATABASE fails."""
+    from backend.routes.admin.admin_backup import restore_backup
+
+    mock_parse.return_value = {
+        "host": "localhost", "port": "5432",
+        "user": "postgres", "password": "", "dbname": "testdb",
+    }
+    mock_s3.return_value = MagicMock()
+
+    # First call (terminate) succeeds, second (drop) fails
+    mock_run.side_effect = [
+        MagicMock(returncode=0),  # terminate connections
+        MagicMock(returncode=1, stderr="permission denied"),  # drop
+    ]
+
+    with pytest.raises(RuntimeError, match="DROP DATABASE failed"):
+        restore_backup("backups/test.sql")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: .
       dockerfile: ./backend/docker_utils/Dockerfile
+      args:
+        - RUNTIME_PACKAGES=postgresql18-client
     # Dev: single-worker uvicorn with hot reload. Production uses the Dockerfile CMD (gunicorn).
     command: uvicorn backend.api:app --host 0.0.0.0 --port 8000 --reload
     ports:
@@ -16,6 +18,8 @@ services:
       - SECRET_KEY=${SECRET_KEY:-test_secret_key_for_tests}
       - DATABASE_URL=${DATABASE_URL:-postgresql+psycopg://postgres:local_pw@postgres:5432/agent_games}
       - DB_ENVIRONMENT=${DB_ENVIRONMENT:-production}
+    env_file:
+      - .aws.env
     depends_on:
       validator:
         condition: service_healthy

--- a/frontend/src/AgentGames/Admin/AdminBackup.jsx
+++ b/frontend/src/AgentGames/Admin/AdminBackup.jsx
@@ -1,0 +1,187 @@
+import React, { useState, useEffect } from 'react';
+import { toast } from 'react-toastify';
+import { useNavigate } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import { checkTokenExpiry } from '../../slices/authSlice';
+import { authFetch } from '../../utils/authFetch';
+
+function AdminBackup() {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const apiUrl = useSelector((state) => state.settings.agentApiUrl);
+  const accessToken = useSelector((state) => state.auth.token);
+  const currentUser = useSelector((state) => state.auth.currentUser);
+  const isAuthenticated = useSelector((state) => state.auth.isAuthenticated);
+
+  const [backups, setBackups] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isCreating, setIsCreating] = useState(false);
+  const [restoringKey, setRestoringKey] = useState(null);
+
+  useEffect(() => {
+    const tokenExpired = dispatch(checkTokenExpiry());
+    if (!isAuthenticated || currentUser.role !== 'admin' || tokenExpired) {
+      navigate('/Admin');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    fetchBackups();
+  }, [apiUrl, accessToken]);
+
+  const fetchBackups = () => {
+    setIsLoading(true);
+    authFetch(`${apiUrl}/admin/list-backups`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.status === 'success') {
+          setBackups(data.data.backups || []);
+        } else {
+          toast.error(data.message || 'Failed to load backups');
+        }
+        setIsLoading(false);
+      })
+      .catch((err) => {
+        console.error('Error fetching backups:', err);
+        toast.error('Error connecting to server');
+        setIsLoading(false);
+      });
+  };
+
+  const handleCreateBackup = () => {
+    if (!window.confirm('Create a new database backup? This may take a moment.')) return;
+
+    setIsCreating(true);
+    authFetch(`${apiUrl}/admin/backup-database`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.status === 'success') {
+          toast.success(data.message || 'Backup created successfully');
+          fetchBackups();
+        } else {
+          toast.error(data.message || 'Backup failed');
+        }
+        setIsCreating(false);
+      })
+      .catch((err) => {
+        console.error('Error creating backup:', err);
+        toast.error('Error connecting to server');
+        setIsCreating(false);
+      });
+  };
+
+  const handleRestore = (backup) => {
+    if (!window.confirm(
+      `WARNING: This will DROP the current database and restore from "${backup.filename}". This cannot be undone. Are you sure?`
+    )) return;
+
+    if (!window.confirm(
+      'This is your last chance to cancel. All current data will be permanently replaced. Continue?'
+    )) return;
+
+    setRestoringKey(backup.s3_key);
+    authFetch(`${apiUrl}/admin/restore-database`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({ s3_key: backup.s3_key }),
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.status === 'success') {
+          toast.success(data.message || 'Database restored successfully');
+        } else {
+          toast.error(data.message || 'Restore failed');
+        }
+        setRestoringKey(null);
+      })
+      .catch((err) => {
+        console.error('Error restoring backup:', err);
+        toast.error('Error connecting to server');
+        setRestoringKey(null);
+      });
+  };
+
+  const formatSize = (bytes) => {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  };
+
+  const formatDate = (iso) => {
+    return new Date(iso).toLocaleString();
+  };
+
+  return (
+    <div className="min-h-screen bg-ui-lighter pt-20 px-6 pb-8">
+      <div className="max-w-7xl mx-auto">
+        <div className="bg-white rounded-lg shadow-lg p-6">
+          <div className="flex justify-between items-center mb-6">
+            <h1 className="text-2xl font-bold text-ui-dark">Database Backups</h1>
+            <button
+              onClick={handleCreateBackup}
+              disabled={isCreating}
+              className="px-4 py-2 bg-success hover:bg-success-hover text-white rounded-lg transition-colors disabled:opacity-50"
+            >
+              {isCreating ? 'Creating Backup...' : 'Create Backup'}
+            </button>
+          </div>
+
+          {isLoading ? (
+            <div className="flex justify-center items-center h-32">
+              <div className="text-lg text-ui-dark">Loading backups...</div>
+            </div>
+          ) : backups.length === 0 ? (
+            <div className="text-center py-8">
+              <p className="text-lg text-ui">No backups found. Create one to get started.</p>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse">
+                <thead>
+                  <tr className="bg-ui-lighter">
+                    <th className="px-4 py-2 text-left text-ui-dark">Filename</th>
+                    <th className="px-4 py-2 text-left text-ui-dark">Size</th>
+                    <th className="px-4 py-2 text-left text-ui-dark">Date</th>
+                    <th className="px-4 py-2 text-left text-ui-dark">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {backups.map((backup) => (
+                    <tr key={backup.s3_key} className="border-b border-ui-light hover:bg-ui-lighter/50">
+                      <td className="px-4 py-3 font-mono text-sm">{backup.filename}</td>
+                      <td className="px-4 py-3">{formatSize(backup.size_bytes)}</td>
+                      <td className="px-4 py-3">{formatDate(backup.last_modified)}</td>
+                      <td className="px-4 py-3">
+                        <button
+                          onClick={() => handleRestore(backup)}
+                          disabled={restoringKey !== null}
+                          className="px-3 py-1 bg-primary hover:bg-primary-hover text-white text-sm rounded transition-colors disabled:opacity-50"
+                        >
+                          {restoringKey === backup.s3_key ? 'Restoring...' : 'Restore'}
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AdminBackup;

--- a/frontend/src/AgentGames/User/AgentLogin.jsx
+++ b/frontend/src/AgentGames/User/AgentLogin.jsx
@@ -11,12 +11,15 @@ function AgentLogin() {
   const dispatch = useDispatch();
   const currentUser = useSelector((state) => state.auth.currentUser);
   const isAuthenticated = useSelector((state) => state.auth.isAuthenticated);
+  const apiUrl = useSelector((state) => state.settings.agentApiUrl);
 
+  const [institutions, setInstitutions] = useState([]);
+  const [selectedInstitution, setSelectedInstitution] = useState(null);
   const [team, setTeam] = useState({ name: "", password: "" });
   const [errorMessage, setErrorMessage] = useState("");
   const [shake, setShake] = useState(false);
+  const [loadingInstitutions, setLoadingInstitutions] = useState(true);
 
-  // Use the authentication hook
   const { teamLogin, isLoading } = useAuthAPI();
 
   useEffect(() => {
@@ -27,6 +30,23 @@ function AgentLogin() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEffect(() => {
+    const fetchInstitutions = async () => {
+      try {
+        const response = await fetch(`${apiUrl}/auth/institutions`);
+        const data = await response.json();
+        if (data.status === "success") {
+          setInstitutions(data.data.institutions);
+        }
+      } catch (error) {
+        console.error('Error fetching institutions:', error);
+      } finally {
+        setLoadingInstitutions(false);
+      }
+    };
+    fetchInstitutions();
+  }, [apiUrl]);
+
   const handleChange = (e) => {
     setTeam((prev) => ({
       ...prev,
@@ -36,15 +56,13 @@ function AgentLogin() {
   };
 
   const handleLogin = async () => {
-    // Basic validation
     if (!team.name.trim() || !team.password.trim()) {
       setShake(true);
       setTimeout(() => setShake(false), 1000);
-      setErrorMessage("Please Enter all the fields");
+      setErrorMessage("Please enter all the fields");
       return;
     }
 
-    // Call the login API using our hook
     const result = await teamLogin(team.name, team.password);
 
     if (result.success) {
@@ -54,7 +72,13 @@ function AgentLogin() {
     }
   };
 
-  const inputClasses = `w-full px-4 py-2 text-lg rounded-lg transition-all duration-200 
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') {
+      handleLogin();
+    }
+  };
+
+  const inputClasses = `w-full px-4 py-2 text-lg rounded-lg transition-all duration-200
     border border-ui-light/20 focus:outline-none focus:ring-1 focus:ring-primary/30
     ${shake ? 'animate-shake border-danger' : 'focus:border-primary/30'}`;
 
@@ -63,56 +87,103 @@ function AgentLogin() {
       <div className="w-full max-w-[800px] px-4">
         <InstructionPopup homescreen={true} />
 
-        <div className="bg-white rounded-lg shadow-lg p-8 border border-ui-light/10">
-          <div className="space-y-6">
-            <div className="space-y-2">
-              <label className="block text-xl font-medium text-ui-dark">
-                Username:
-              </label>
-              <input
-                type="text"
-                id="team_name"
-                name="name"
-                onChange={handleChange}
-                className={inputClasses}
-                placeholder="Enter your username"
-              />
-            </div>
+        {!selectedInstitution ? (
+          <div className="bg-white rounded-lg shadow-lg p-8 border border-ui-light/10">
+            <h2 className="text-2xl font-semibold text-ui-dark mb-6 text-center">
+              Select Your Institution
+            </h2>
 
-            <div className="space-y-2">
-              <label className="block text-xl font-medium text-ui-dark">
-                Password:
-              </label>
-              <input
-                type="password"
-                id="team_password"
-                name="password"
-                onChange={handleChange}
-                className={inputClasses}
-                placeholder="Enter your password"
-              />
-            </div>
-
-            <UserTooltip
-              title="⚠️ INFO <br />Enter your login details provided by your teacher or school and then login."
-              arrow
-              disableFocusListener
-              disableTouchListener
-            >
-              <button
-                onClick={handleLogin}
-                disabled={isLoading}
-                className="w-full py-3 px-4 text-lg font-medium text-white bg-primary hover:bg-primary-hover rounded-lg transition-colors duration-200 disabled:bg-ui-light disabled:cursor-not-allowed"
-              >
-                {isLoading ? "Logging in..." : "Login"}
-              </button>
-            </UserTooltip>
-
-            {errorMessage && (
-              <p className="text-lg text-danger text-center">{errorMessage}</p>
+            {loadingInstitutions ? (
+              <p className="text-center text-ui-dark/60">Loading institutions...</p>
+            ) : institutions.length === 0 ? (
+              <p className="text-center text-ui-dark/60">No institutions available</p>
+            ) : (
+              <div className="space-y-3">
+                {institutions.map((name) => (
+                  <button
+                    key={name}
+                    onClick={() => {
+                      setSelectedInstitution(name);
+                      setErrorMessage("");
+                    }}
+                    className="w-full py-4 px-6 text-lg font-medium text-left rounded-lg border border-ui-light/20 hover:border-primary hover:bg-primary/5 transition-all duration-200"
+                  >
+                    {name}
+                  </button>
+                ))}
+              </div>
             )}
           </div>
-        </div>
+        ) : (
+          <div className="bg-white rounded-lg shadow-lg p-8 border border-ui-light/10">
+            <button
+              onClick={() => {
+                setSelectedInstitution(null);
+                setTeam({ name: "", password: "" });
+                setErrorMessage("");
+              }}
+              className="text-primary hover:text-primary-hover text-sm font-medium mb-4 flex items-center gap-1"
+            >
+              &larr; Back to institutions
+            </button>
+
+            <h2 className="text-2xl font-semibold text-ui-dark mb-6 text-center">
+              {selectedInstitution}
+            </h2>
+
+            <div className="space-y-6">
+              <div className="space-y-2">
+                <label className="block text-xl font-medium text-ui-dark">
+                  Username:
+                </label>
+                <input
+                  type="text"
+                  id="team_name"
+                  name="name"
+                  onChange={handleChange}
+                  onKeyDown={handleKeyDown}
+                  className={inputClasses}
+                  placeholder="Enter your username"
+                  autoFocus
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label className="block text-xl font-medium text-ui-dark">
+                  Password:
+                </label>
+                <input
+                  type="password"
+                  id="team_password"
+                  name="password"
+                  onChange={handleChange}
+                  onKeyDown={handleKeyDown}
+                  className={inputClasses}
+                  placeholder="Enter your password"
+                />
+              </div>
+
+              <UserTooltip
+                title="&#9888;&#65039; INFO <br />Enter your login details provided by your teacher or school and then login."
+                arrow
+                disableFocusListener
+                disableTouchListener
+              >
+                <button
+                  onClick={handleLogin}
+                  disabled={isLoading}
+                  className="w-full py-3 px-4 text-lg font-medium text-white bg-primary hover:bg-primary-hover rounded-lg transition-colors duration-200 disabled:bg-ui-light disabled:cursor-not-allowed"
+                >
+                  {isLoading ? "Logging in..." : "Login"}
+                </button>
+              </UserTooltip>
+
+              {errorMessage && (
+                <p className="text-lg text-danger text-center">{errorMessage}</p>
+              )}
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,7 @@ import Leaderboards from "./AgentGames/Leaderboards";
 import Admin from "./AgentGames/Admin/Admin";
 import AdminLeague from "./AgentGames/Admin/AdminLeague";
 import AdminLeagueSimulation from "./AgentGames/Admin/AdminLeagueSimulation";
+import AdminBackup from "./AgentGames/Admin/AdminBackup";
 import AdminInstitutions from "./AgentGames/Admin/AdminInstitutions";
 import StyleGuide from "./StyleGuide";
 import PublishedResults from "./AgentGames/PublishedResults";
@@ -63,6 +64,7 @@ function App() {
           />
           <Route path="AdminInstitutions" element={<AdminInstitutions />} />
           {/* <Route path="AdminDemoUsers" element={<AdminDemoUsers />} /> */}
+          <Route path="AdminBackup" element={<AdminBackup />} />
           <Route path="AdminDockerStatus" element={<DockerStatus />} />
           {/* Institution Routes */}
           <Route path="Institution" element={<Institution />} />

--- a/frontend/src/Navbar.jsx
+++ b/frontend/src/Navbar.jsx
@@ -12,6 +12,7 @@ function AgentGamesNavbar() {
   const dispatch = useDispatch();
 
   const adminRoutes = [
+    "/AdminBackup",
     "/AdminDockerStatus",
     "/AdminInstitutions",
   ];
@@ -58,6 +59,9 @@ function AgentGamesNavbar() {
                 </Link>
                 <Link to="/AdminDockerStatus" className={navLinkClasses}>
                   Service Status
+                </Link>
+                <Link to="/AdminBackup" className={navLinkClasses}>
+                  Backups
                 </Link>
               </>
             ) : isInstitutionRoute ? (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Agent Games Backend"
 requires-python = ">=3.14"
 dependencies = [
     "bcrypt>=5.0.0",
+    "boto3>=1.35.0",
     "docker>=7.1.0",
     "email-validator>=2.3.0",
     "fastapi>=0.135.0",

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },
+    { name = "boto3" },
     { name = "docker" },
     { name = "email-validator" },
     { name = "fastapi" },
@@ -36,6 +37,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "bcrypt", specifier = ">=5.0.0" },
+    { name = "boto3", specifier = ">=1.35.0" },
     { name = "docker", specifier = ">=7.1.0" },
     { name = "email-validator", specifier = ">=2.3.0" },
     { name = "fastapi", specifier = ">=0.135.0" },
@@ -140,6 +142,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/f6/688d2cd64bfd0b14d805ddb8a565e11ca1fb0fd6817175d58b10052b6d88/bcrypt-5.0.0-cp39-abi3-win32.whl", hash = "sha256:64d7ce196203e468c457c37ec22390f1a61c85c6f0b8160fd752940ccfb3a683", size = 153725, upload-time = "2025-09-25T19:50:34.384Z" },
     { url = "https://files.pythonhosted.org/packages/9f/b9/9d9a641194a730bda138b3dfe53f584d61c58cd5230e37566e83ec2ffa0d/bcrypt-5.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:64ee8434b0da054d830fa8e89e1c8bf30061d539044a39524ff7dec90481e5c2", size = 150912, upload-time = "2025-09-25T19:50:35.69Z" },
     { url = "https://files.pythonhosted.org/packages/27/44/d2ef5e87509158ad2187f4dd0852df80695bb1ee0cfe0a684727b01a69e0/bcrypt-5.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:f2347d3534e76bf50bca5500989d6c1d05ed64b440408057a37673282c654927", size = 144953, upload-time = "2025-09-25T19:50:37.32Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.42.83"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/87/1ed88eaa1e814841a37e71fee74c2b74341d14b791c0c6038b7ba914bea1/boto3-1.42.83.tar.gz", hash = "sha256:cc5621e603982cb3145b7f6c9970e02e297a1a0eb94637cc7f7b69d3017640ee", size = 112719, upload-time = "2026-04-03T19:34:21.254Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/b1/8a066bc8f02937d49783c0b3948ab951d8284e6fde436cab9f359dbd4d93/boto3-1.42.83-py3-none-any.whl", hash = "sha256:544846fdb10585bb7837e409868e8e04c6b372fa04479ba1597ce82cf1242076", size = 140555, upload-time = "2026-04-03T19:34:17.935Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.83"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/01/b46a3f8b6e9362258f78f1890db1a96d4ed73214d6a36420dc158dcfd221/botocore-1.42.83.tar.gz", hash = "sha256:34bc8cb64b17ac17f8901f073fe4fc9572a5cac9393a37b2b3ea372a83b87f4a", size = 15140337, upload-time = "2026-04-03T19:34:08.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/97/0d6f50822dc8c1df7f3eadb0bc6822fc0f98f02287c4efc7c7c88fde129a/botocore-1.42.83-py3-none-any.whl", hash = "sha256:ec0c3ecb3772936ed22a3bdda09883b34858933f71004686d460d829bab39d8e", size = 14818388, upload-time = "2026-04-03T19:34:03.333Z" },
 ]
 
 [[package]]
@@ -508,6 +538,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -684,6 +723,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -790,6 +841,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add institution selector to player login page — players now choose their institution before entering credentials                                                                                            
- Add GET /auth/institutions public endpoint returning active institution names for the login selector                          
- Scope league visibility by institution — regular institutions see only their own leagues, students see only their institution's leagues                                                                     
- Grant admin role and Admin Institution (id=1) full access to view, simulate, publish, and delete any institution's leagues                                                                                  
- Fix 3 broken endpoints (/publish-results, /delete-league, /assign-team-to-league) that previously failed for admin users due to missing institution_id fallback                                             
- Standardize admin permission handling via _resolve_institution() helper across all institution router endpoints                                                                                             
- Remove redundant except Exception catch-all blocks from DB layer functions, improving code clarity while keeping them in router endpoints as the safety net                                                 
- Add 56 new tests covering: institution-scoped permissions, cross-institution access control, public institutions endpoint, direct league signup, league submissions, admin backup operations, agent team    
management, and demo cleanup functions                                                                                                                                                                        
- Rebuild Docker images to include boto3 dependency (was missing, blocking all tests on the backups branch) 