### PR TITLE
School league

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,7 @@ backend/games/arena_champions/validation_players.py
 
 docs/
 seed_prod.py
+
+# Binary assets hosted on S3, not committed
+frontend/public/videos/*.mp4
+frontend/public/about/

--- a/backend/database/db_models.py
+++ b/backend/database/db_models.py
@@ -3,7 +3,7 @@ from enum import Enum as PyEnum
 from typing import List, Optional
 
 import bcrypt as _bcrypt
-from sqlalchemy import Column, DateTime, String, Text
+from sqlalchemy import JSON, Column, DateTime, String, Text
 from sqlmodel import Field, Relationship, SQLModel, UniqueConstraint
 
 
@@ -63,6 +63,11 @@ class League(SQLModel, table=True):
     game: str
     league_type: LeagueType = Field(default=LeagueType.STUDENT)
     is_demo: bool = Field(default=False)
+    school_league: bool = Field(default=False)
+    schools_config: Optional[dict] = Field(
+        default=None,
+        sa_column=Column(JSON, nullable=True),
+    )
     simulation_results: List["SimulationResult"] = Relationship(back_populates="league")
     # New field for institution relationship
     institution_id: Optional[int] = Field(default=None, foreign_key="institution.id")

--- a/backend/docker_utils/migrations/2026-04-19_school_leagues.sql
+++ b/backend/docker_utils/migrations/2026-04-19_school_leagues.sql
@@ -1,0 +1,11 @@
+-- School leagues: add school_league flag and schools_config JSON column.
+-- Idempotent: safe to run multiple times on existing DBs.
+-- For fresh DBs, SQLModel.metadata.create_all() in init_db.py creates these
+-- columns automatically from the model definition; running this script is a
+-- no-op in that case.
+
+ALTER TABLE league
+  ADD COLUMN IF NOT EXISTS school_league BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE league
+  ADD COLUMN IF NOT EXISTS schools_config JSON NULL;

--- a/backend/routes/institution/institution_db.py
+++ b/backend/routes/institution/institution_db.py
@@ -58,6 +58,14 @@ def create_league(session: Session, league_data, institution_id: int) -> Dict:
     # Generate unique signup token
     signup_token = secrets.token_urlsafe(16)
 
+    school_league = bool(league_data.get("school_league", False))
+    schools_config = None
+    if school_league:
+        schools_config = {
+            "source": "static",
+            "schools": list(league_data.get("schools", [])),
+        }
+
     # Create the league
     league = League(
         name=league_data["name"],
@@ -69,6 +77,8 @@ def create_league(session: Session, league_data, institution_id: int) -> Dict:
         institution_id=institution_id,
         league_type=LeagueType.INSTITUTION,
         signup_link=signup_token,
+        school_league=school_league,
+        schools_config=schools_config,
     )
 
     session.add(league)
@@ -78,6 +88,7 @@ def create_league(session: Session, league_data, institution_id: int) -> Dict:
         "league_id": league.id,
         "name": league.name,
         "signup_token": signup_token,
+        "school_league": school_league,
     }
 
 

--- a/backend/routes/institution/institution_models.py
+++ b/backend/routes/institution/institution_models.py
@@ -1,7 +1,8 @@
+import re
 from datetime import datetime
 from typing import List, Optional, Union
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from backend.utils import get_games_names
 
@@ -13,6 +14,8 @@ class LeagueSignUp(BaseModel):
 
     name: str
     game: str
+    school_league: bool = False
+    schools: List[str] = []
 
     @field_validator("name")
     def validate_name(cls, v):
@@ -26,6 +29,27 @@ class LeagueSignUp(BaseModel):
         if v not in valid_games:
             raise ValueError(f"Game must be one of: {', '.join(valid_games)}")
         return v
+
+    @field_validator("schools")
+    def dedupe_and_strip(cls, v):
+        seen, out = set(), []
+        for s in v:
+            s2 = (s or "").strip()
+            if not s2 or s2 in seen:
+                continue
+            if not re.sub(r"[^A-Za-z0-9]", "", s2):
+                raise ValueError(
+                    f"School name '{s2}' must contain at least one alphanumeric character"
+                )
+            seen.add(s2)
+            out.append(s2)
+        return out
+
+    @model_validator(mode="after")
+    def require_schools_when_school_league(self):
+        if self.school_league and not self.schools:
+            raise ValueError("A school league must include at least one school")
+        return self
 
 
 class TeamSignup(BaseModel):

--- a/backend/routes/user/team_naming.py
+++ b/backend/routes/user/team_naming.py
@@ -1,0 +1,96 @@
+import logging
+import re
+
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import Session, select
+
+from backend.database.db_models import League, Team, TeamType
+
+logger = logging.getLogger(__name__)
+MAX_COLLISION_RETRIES = 10
+
+
+def sanitize_school_name(s: str) -> str:
+    """Strip all non-alphanumerics; preserve casing.
+
+    'Willetton SHS!' -> 'WillettonSHS'. Accents/non-ASCII are stripped (e.g.
+    'École' -> 'cole'); callers that need Unicode should pre-normalize.
+    """
+    return re.sub(r"[^A-Za-z0-9]", "", s or "")
+
+
+def next_available_team_name(session: Session, sanitized: str, start: int = 1) -> str:
+    """Find the lowest N >= start such that f'{sanitized}{N}' is globally unused
+    as Team.name.
+
+    Counter scope: Team.name is globally unique, so this is effectively a
+    "next globally-unused N". In practice it matches per-league counting;
+    when the same sanitized school appears across leagues, N skips past
+    whichever numbers are already taken.
+    """
+    if not sanitized:
+        raise ValueError("Sanitized school name is empty; cannot derive team name")
+
+    existing = session.exec(
+        select(Team.name).where(Team.name.like(f"{sanitized}%"))
+    ).all()
+
+    used = set()
+    for name in existing:
+        suffix = name[len(sanitized):]
+        if suffix.isdigit():
+            used.add(int(suffix))
+
+    n = start
+    while n in used:
+        n += 1
+    return f"{sanitized}{n}"
+
+
+def create_school_team(
+    session: Session, league_id: int, school_name: str, password: str
+) -> Team:
+    """Create a team for a school league with sanitized name + counter.
+
+    Race-safe: on IntegrityError from the unique-name constraint, bump the
+    counter past the collision and retry up to MAX_COLLISION_RETRIES times.
+    """
+    league = session.get(League, league_id)
+    if not league:
+        raise ValueError(f"League {league_id} not found")
+
+    sanitized = sanitize_school_name(school_name)
+    if not sanitized:
+        raise ValueError(
+            f"School name '{school_name}' contains no alphanumerics"
+        )
+
+    start = 1
+    for attempt in range(MAX_COLLISION_RETRIES):
+        candidate = next_available_team_name(session, sanitized, start=start)
+        try:
+            team = Team(
+                name=candidate,
+                school_name=school_name,
+                league_id=league_id,
+                institution_id=league.institution_id,
+                team_type=TeamType.STUDENT,
+            )
+            team.set_password(password)
+            session.add(team)
+            session.commit()
+            session.refresh(team)
+            return team
+        except IntegrityError:
+            session.rollback()
+            logger.warning(
+                "Race on team name %s; retrying (attempt %d)", candidate, attempt + 1
+            )
+            try:
+                start = int(candidate[len(sanitized):]) + 1
+            except ValueError:
+                start += 1
+            continue
+    raise RuntimeError(
+        f"Failed to create school team after {MAX_COLLISION_RETRIES} retries"
+    )

--- a/backend/routes/user/user_models.py
+++ b/backend/routes/user/user_models.py
@@ -46,3 +46,21 @@ class DirectLeagueSignup(BaseModel):
         if not v.strip():
             raise ValueError("Field cannot be empty")
         return v.strip()
+
+
+class DirectSchoolLeagueSignup(BaseModel):
+    """Model for direct team signup for a school league.
+
+    Team name is server-generated from the selected school + counter — not
+    supplied by the client. No email; password is the only credential.
+    """
+
+    signup_token: str
+    school_name: str
+    password: str
+
+    @field_validator("signup_token", "school_name", "password")
+    def validate_not_empty(cls, v):
+        if not v.strip():
+            raise ValueError("Field cannot be empty")
+        return v.strip()

--- a/backend/routes/user/user_router.py
+++ b/backend/routes/user/user_router.py
@@ -45,10 +45,17 @@ from backend.routes.user.user_db import (
 )
 from backend.routes.user.user_models import (
     DirectLeagueSignup,
+    DirectSchoolLeagueSignup,
     GameName,
     LeagueAssignRequest,
     SubmissionCode,
 )
+from backend.routes.user.team_naming import (
+    create_school_team,
+    next_available_team_name,
+    sanitize_school_name,
+)
+from backend.schools.providers import SchoolsProviderError, get_schools_provider
 from backend.utils import get_games_names
 
 logger = logging.getLogger(__name__)
@@ -450,21 +457,116 @@ async def get_league_by_token(
                 status="error", message="Invalid signup link or league not found"
             )
 
+        data = {
+            "id": league.id,
+            "name": league.name,
+            "game": league.game,
+            "created_date": league.created_date,
+            "expiry_date": league.expiry_date,
+            "school_league": league.school_league,
+        }
+
+        if league.school_league:
+            try:
+                provider = get_schools_provider(league)
+                schools = provider.list_schools() if provider else []
+            except SchoolsProviderError as e:
+                logger.error(f"Schools provider error for league {league.id}: {e}")
+                schools = []
+            data["schools"] = schools
+            # Advisory preview; real name is assigned server-side at signup.
+            data["team_name_previews"] = {
+                s: next_available_team_name(session, sanitize_school_name(s))
+                for s in schools
+                if sanitize_school_name(s)
+            }
+
         return ResponseModel(
             status="success",
             message="League information retrieved successfully",
-            data={
-                "id": league.id,
-                "name": league.name,
-                "game": league.game,
-                "created_date": league.created_date,
-                "expiry_date": league.expiry_date,
-            },
+            data=data,
         )
     except Exception as e:
         logger.error(f"Error retrieving league by token: {e}")
         return ErrorResponseModel(
             status="error", message=f"Failed to retrieve league information: {str(e)}"
+        )
+
+
+@user_router.post("/direct-school-league-signup", response_model=ResponseModel)
+async def direct_school_league_signup(
+    signup: DirectSchoolLeagueSignup,
+    session: Session = Depends(get_db),
+):
+    """Create a team in a school league using the server-assigned team name."""
+    try:
+        league = get_league_by_signup_token(session, signup.signup_token)
+
+        if not league:
+            return ErrorResponseModel(
+                status="error", message="Invalid signup link or league not found"
+            )
+
+        if not league.school_league:
+            return ErrorResponseModel(
+                status="error", message="This league is not a school league"
+            )
+
+        now = datetime.now(AUSTRALIA_SYDNEY_TZ)
+        expiry_date = league.expiry_date
+        if expiry_date.tzinfo is None:
+            expiry_date = AUSTRALIA_SYDNEY_TZ.localize(expiry_date)
+        if expiry_date < now:
+            return ErrorResponseModel(
+                status="error",
+                message="This league has expired and is no longer accepting new teams",
+            )
+
+        try:
+            provider = get_schools_provider(league)
+        except SchoolsProviderError as e:
+            return ErrorResponseModel(
+                status="error", message=f"School list unavailable: {str(e)}"
+            )
+
+        allowed = set(provider.list_schools()) if provider else set()
+        if signup.school_name not in allowed:
+            return ErrorResponseModel(
+                status="error",
+                message=(
+                    f"School '{signup.school_name}' is not in this league's "
+                    "allowed list"
+                ),
+            )
+
+        team = create_school_team(
+            session, league.id, signup.school_name, signup.password
+        )
+
+        access_token = create_access_token(
+            data={"sub": team.name, "role": "student"},
+            expires_delta=timedelta(minutes=TEAM_TOKEN_EXPIRY_MINUTES),
+        )
+
+        return ResponseModel(
+            status="success",
+            message=(
+                f"Team '{team.name}' created and assigned to league "
+                f"'{league.name}' successfully!"
+            ),
+            data={
+                "team_id": team.id,
+                "team_name": team.name,
+                "league_id": league.id,
+                "league_name": league.name,
+                "access_token": access_token,
+                "token_type": "bearer",
+            },
+        )
+    except Exception as e:
+        logger.error(f"Error in direct school-league signup: {e}")
+        return ErrorResponseModel(
+            status="error", message=f"Failed to complete signup: {str(e)}"
         )
 
 

--- a/backend/schools/providers.py
+++ b/backend/schools/providers.py
@@ -1,0 +1,29 @@
+from typing import List, Optional, Protocol
+
+from backend.database.db_models import League
+
+
+class SchoolsProvider(Protocol):
+    def list_schools(self) -> List[str]: ...
+
+
+class StaticSchoolsProvider:
+    def __init__(self, schools: List[str]):
+        self._schools = [s.strip() for s in schools if s and s.strip()]
+
+    def list_schools(self) -> List[str]:
+        return list(self._schools)
+
+
+class SchoolsProviderError(Exception):
+    """Raised when a SchoolsProvider cannot be built from a League's schools_config."""
+
+
+def get_schools_provider(league: League) -> Optional[SchoolsProvider]:
+    if not league.school_league:
+        return None
+    cfg = league.schools_config or {}
+    source = cfg.get("source", "static")
+    if source == "static":
+        return StaticSchoolsProvider(cfg.get("schools", []))
+    raise SchoolsProviderError(f"Unknown schools source: {source}")

--- a/backend/tests/integration/routes/institution/test_school_league_create.py
+++ b/backend/tests/integration/routes/institution/test_school_league_create.py
@@ -1,0 +1,154 @@
+"""Tests for POST /institution/league-create with school_league flag."""
+
+from datetime import datetime, timedelta
+
+import pytest
+from sqlmodel import Session, select
+
+from backend.database.db_models import Institution, League
+from backend.routes.auth.auth_core import create_access_token
+
+
+@pytest.fixture
+def institution_token(db_session: Session) -> str:
+    institution = Institution(
+        name="school_league_test_institution",
+        contact_person="Test Person",
+        contact_email="test@example.com",
+        created_date=datetime.now(),
+        subscription_active=True,
+        subscription_expiry=datetime.now() + timedelta(days=30),
+        docker_access=True,
+        password_hash="test_hash",
+    )
+    db_session.add(institution)
+    db_session.commit()
+    db_session.refresh(institution)
+
+    return create_access_token(
+        data={
+            "sub": institution.name,
+            "role": "institution",
+            "institution_id": institution.id,
+        },
+        expires_delta=timedelta(minutes=30),
+    )
+
+
+@pytest.fixture
+def institution_headers(institution_token: str) -> dict:
+    return {"Authorization": f"Bearer {institution_token}"}
+
+
+def test_school_league_create_success(client, institution_headers, db_session):
+    resp = client.post(
+        "/institution/league-create",
+        headers=institution_headers,
+        json={
+            "name": "school_league_happy",
+            "game": "greedy_pig",
+            "school_league": True,
+            "schools": ["Willetton SHS", "Perth Modern"],
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "success", data
+    assert data["data"]["school_league"] is True
+
+    league = db_session.exec(
+        select(League).where(League.name == "school_league_happy")
+    ).first()
+    assert league is not None
+    assert league.school_league is True
+    assert league.schools_config == {
+        "source": "static",
+        "schools": ["Willetton SHS", "Perth Modern"],
+    }
+
+
+def test_school_league_requires_schools(client, institution_headers):
+    resp = client.post(
+        "/institution/league-create",
+        headers=institution_headers,
+        json={
+            "name": "school_league_empty",
+            "game": "greedy_pig",
+            "school_league": True,
+            "schools": [],
+        },
+    )
+    assert resp.status_code == 422
+    assert "at least one school" in str(resp.json()).lower()
+
+
+def test_non_school_league_ignores_schools(client, institution_headers, db_session):
+    resp = client.post(
+        "/institution/league-create",
+        headers=institution_headers,
+        json={
+            "name": "non_school_with_schools_arg",
+            "game": "greedy_pig",
+            "school_league": False,
+            "schools": ["Should be ignored"],
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "success"
+
+    league = db_session.exec(
+        select(League).where(League.name == "non_school_with_schools_arg")
+    ).first()
+    assert league is not None
+    assert league.school_league is False
+    assert league.schools_config is None
+
+
+def test_school_list_dedup_and_strip(client, institution_headers, db_session):
+    resp = client.post(
+        "/institution/league-create",
+        headers=institution_headers,
+        json={
+            "name": "school_league_dedup",
+            "game": "greedy_pig",
+            "school_league": True,
+            "schools": ["  Willetton  ", "Willetton", "", "Perth Modern", "Willetton"],
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "success"
+
+    league = db_session.exec(
+        select(League).where(League.name == "school_league_dedup")
+    ).first()
+    assert league.schools_config["schools"] == ["Willetton", "Perth Modern"]
+
+
+def test_school_list_rejects_punctuation_only(client, institution_headers):
+    resp = client.post(
+        "/institution/league-create",
+        headers=institution_headers,
+        json={
+            "name": "school_league_punct",
+            "game": "greedy_pig",
+            "school_league": True,
+            "schools": ["!!!"],
+        },
+    )
+    assert resp.status_code == 422
+    assert "alphanumeric" in str(resp.json()).lower()
+
+
+def test_default_school_league_false(client, institution_headers, db_session):
+    """Leagues created without the flag default to school_league=False."""
+    resp = client.post(
+        "/institution/league-create",
+        headers=institution_headers,
+        json={"name": "classic_league", "game": "greedy_pig"},
+    )
+    assert resp.status_code == 200
+    league = db_session.exec(
+        select(League).where(League.name == "classic_league")
+    ).first()
+    assert league.school_league is False
+    assert league.schools_config is None

--- a/backend/tests/integration/routes/user/test_school_league_signup.py
+++ b/backend/tests/integration/routes/user/test_school_league_signup.py
@@ -1,0 +1,299 @@
+"""Tests for school-league flow: GET /user/league-info and POST /user/direct-school-league-signup."""
+
+import secrets
+from datetime import datetime, timedelta
+
+import pytest
+import pytz
+from jose import jwt
+from sqlmodel import Session, select
+
+from backend.database.db_models import (
+    Institution,
+    League,
+    LeagueType,
+    Team,
+    TeamType,
+)
+from backend.routes.auth.auth_config import ALGORITHM, SECRET_KEY
+
+AUSTRALIA_SYDNEY_TZ = pytz.timezone("Australia/Sydney")
+
+
+@pytest.fixture
+def school_league_fixture(db_session: Session) -> dict:
+    """Create an institution + a school league with a valid signup token."""
+    now = datetime.now(AUSTRALIA_SYDNEY_TZ)
+
+    institution = Institution(
+        name="School League Test School",
+        contact_person="Teacher",
+        contact_email="teacher@school.com",
+        created_date=now,
+        subscription_active=True,
+        subscription_expiry=now + timedelta(days=30),
+        docker_access=True,
+        password_hash="hash",
+    )
+    db_session.add(institution)
+    db_session.commit()
+    db_session.refresh(institution)
+
+    token = secrets.token_urlsafe(16)
+    league = League(
+        name="school_signup_test_league",
+        created_date=now,
+        expiry_date=now + timedelta(days=7),
+        game="greedy_pig",
+        institution_id=institution.id,
+        league_type=LeagueType.INSTITUTION,
+        signup_link=token,
+        school_league=True,
+        schools_config={
+            "source": "static",
+            "schools": ["Willetton SHS", "Perth Modern"],
+        },
+    )
+    db_session.add(league)
+    db_session.commit()
+    db_session.refresh(league)
+
+    return {"institution": institution, "league": league, "signup_token": token}
+
+
+@pytest.fixture
+def non_school_league_fixture(db_session: Session) -> dict:
+    now = datetime.now(AUSTRALIA_SYDNEY_TZ)
+    institution = db_session.exec(
+        select(Institution).where(Institution.name == "Admin Institution")
+    ).first()
+
+    token = secrets.token_urlsafe(16)
+    league = League(
+        name="non_school_league_for_rejection",
+        created_date=now,
+        expiry_date=now + timedelta(days=7),
+        game="greedy_pig",
+        institution_id=institution.id,
+        league_type=LeagueType.INSTITUTION,
+        signup_link=token,
+        school_league=False,
+    )
+    db_session.add(league)
+    db_session.commit()
+    db_session.refresh(league)
+    return {"league": league, "signup_token": token}
+
+
+@pytest.fixture
+def expired_school_league_fixture(db_session: Session) -> dict:
+    now = datetime.now(AUSTRALIA_SYDNEY_TZ)
+    institution = db_session.exec(
+        select(Institution).where(Institution.name == "Admin Institution")
+    ).first()
+
+    token = secrets.token_urlsafe(16)
+    league = League(
+        name="expired_school_league",
+        created_date=now - timedelta(days=14),
+        expiry_date=now - timedelta(days=1),
+        game="greedy_pig",
+        institution_id=institution.id,
+        league_type=LeagueType.INSTITUTION,
+        signup_link=token,
+        school_league=True,
+        schools_config={
+            "source": "static",
+            "schools": ["Willetton SHS"],
+        },
+    )
+    db_session.add(league)
+    db_session.commit()
+    db_session.refresh(league)
+    return {"league": league, "signup_token": token}
+
+
+def test_league_info_includes_schools_and_previews(client, school_league_fixture):
+    resp = client.get(f"/user/league-info/{school_league_fixture['signup_token']}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "success"
+    payload = data["data"]
+    assert payload["school_league"] is True
+    assert payload["schools"] == ["Willetton SHS", "Perth Modern"]
+    assert payload["team_name_previews"]["Willetton SHS"] == "WillettonSHS1"
+    assert payload["team_name_previews"]["Perth Modern"] == "PerthModern1"
+
+
+def test_league_info_non_school_omits_schools(client, non_school_league_fixture):
+    resp = client.get(
+        f"/user/league-info/{non_school_league_fixture['signup_token']}"
+    )
+    assert resp.status_code == 200
+    payload = resp.json()["data"]
+    assert payload["school_league"] is False
+    assert "schools" not in payload
+    assert "team_name_previews" not in payload
+
+
+def test_direct_school_signup_happy_path(client, school_league_fixture, db_session):
+    resp = client.post(
+        "/user/direct-school-league-signup",
+        json={
+            "signup_token": school_league_fixture["signup_token"],
+            "school_name": "Willetton SHS",
+            "password": "securepass123",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "success", data
+    result = data["data"]
+    assert result["team_name"] == "WillettonSHS1"
+    assert result["league_id"] == school_league_fixture["league"].id
+
+    decoded = jwt.decode(result["access_token"], SECRET_KEY, algorithms=[ALGORITHM])
+    assert decoded["sub"] == "WillettonSHS1"
+    assert decoded["role"] == "student"
+
+    team = db_session.exec(
+        select(Team).where(Team.name == "WillettonSHS1")
+    ).first()
+    assert team is not None
+    assert team.league_id == school_league_fixture["league"].id
+    assert team.institution_id == school_league_fixture["institution"].id
+    assert team.school_name == "Willetton SHS"
+
+
+def test_direct_school_signup_counter(client, school_league_fixture):
+    token = school_league_fixture["signup_token"]
+    r1 = client.post(
+        "/user/direct-school-league-signup",
+        json={
+            "signup_token": token,
+            "school_name": "Willetton SHS",
+            "password": "pw1",
+        },
+    )
+    r2 = client.post(
+        "/user/direct-school-league-signup",
+        json={
+            "signup_token": token,
+            "school_name": "Willetton SHS",
+            "password": "pw2",
+        },
+    )
+    assert r1.json()["data"]["team_name"] == "WillettonSHS1"
+    assert r2.json()["data"]["team_name"] == "WillettonSHS2"
+
+
+def test_direct_school_signup_school_not_in_list(client, school_league_fixture):
+    resp = client.post(
+        "/user/direct-school-league-signup",
+        json={
+            "signup_token": school_league_fixture["signup_token"],
+            "school_name": "Bogus High",
+            "password": "pw",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "error"
+    assert "not in this league" in body["message"].lower()
+
+
+def test_direct_school_signup_rejects_non_school_league(
+    client, non_school_league_fixture
+):
+    resp = client.post(
+        "/user/direct-school-league-signup",
+        json={
+            "signup_token": non_school_league_fixture["signup_token"],
+            "school_name": "Whatever",
+            "password": "pw",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "error"
+    assert "not a school league" in body["message"].lower()
+
+
+def test_direct_school_signup_expired_league(client, expired_school_league_fixture):
+    resp = client.post(
+        "/user/direct-school-league-signup",
+        json={
+            "signup_token": expired_school_league_fixture["signup_token"],
+            "school_name": "Willetton SHS",
+            "password": "pw",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "error"
+    assert "expired" in body["message"].lower()
+
+
+def test_direct_school_signup_invalid_token(client):
+    resp = client.post(
+        "/user/direct-school-league-signup",
+        json={
+            "signup_token": "bogus_token_12345",
+            "school_name": "Willetton SHS",
+            "password": "pw",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "error"
+
+
+def test_direct_school_signup_skips_cross_league_collision(
+    client, school_league_fixture, db_session
+):
+    """A WillettonSHS1 in another league forces the counter to skip."""
+    other_league = db_session.exec(
+        select(League).where(League.name == "unassigned")
+    ).first()
+    pre_existing = Team(
+        name="WillettonSHS1",
+        school_name="Willetton SHS",
+        password_hash="hash",
+        league_id=other_league.id,
+        team_type=TeamType.STUDENT,
+    )
+    db_session.add(pre_existing)
+    db_session.commit()
+
+    resp = client.post(
+        "/user/direct-school-league-signup",
+        json={
+            "signup_token": school_league_fixture["signup_token"],
+            "school_name": "Willetton SHS",
+            "password": "pw",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["data"]["team_name"] == "WillettonSHS2"
+
+
+def test_direct_league_signup_still_works_for_non_school_league(
+    client, non_school_league_fixture, db_session
+):
+    """Regression: the classic team-signup endpoint is unchanged for non-school leagues."""
+    resp = client.post(
+        "/user/direct-league-signup",
+        json={
+            "team_name": "classic_regression_team",
+            "password": "pw",
+            "signup_token": non_school_league_fixture["signup_token"],
+            "school_name": "Any School",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "success"
+    team = db_session.exec(
+        select(Team).where(Team.name == "classic_regression_team")
+    ).first()
+    assert team is not None
+    assert team.school_name == "Any School"

--- a/backend/tests/unit/routes/user/test_team_naming.py
+++ b/backend/tests/unit/routes/user/test_team_naming.py
@@ -1,0 +1,126 @@
+"""Unit tests for team-name sanitization + counter logic."""
+
+from datetime import datetime, timedelta
+
+import pytest
+import pytz
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import Session, select
+
+from backend.database.db_models import (
+    Institution,
+    League,
+    LeagueType,
+    Team,
+    TeamType,
+)
+from backend.routes.user.team_naming import (
+    create_school_team,
+    next_available_team_name,
+    sanitize_school_name,
+)
+
+AUSTRALIA_SYDNEY_TZ = pytz.timezone("Australia/Sydney")
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("Willetton SHS", "WillettonSHS"),
+        ("Willetton SHS!", "WillettonSHS"),
+        ("   Willetton   SHS   ", "WillettonSHS"),
+        ("St. Mary's College", "StMarysCollege"),
+        ("", ""),
+        ("!!!", ""),
+        ("École", "cole"),  # documented: non-ASCII stripped
+        ("School 7", "School7"),
+    ],
+)
+def test_sanitize_school_name(raw, expected):
+    assert sanitize_school_name(raw) == expected
+
+
+def test_next_available_team_name_empty_db(db_session: Session):
+    # Fresh DB has no Foo-prefixed teams
+    assert next_available_team_name(db_session, "Foo") == "Foo1"
+
+
+def test_next_available_team_name_with_gaps(db_session: Session):
+    league = db_session.exec(select(League).where(League.name == "unassigned")).first()
+    for n in (1, 3):
+        db_session.add(
+            Team(
+                name=f"Foo{n}",
+                school_name="Foo",
+                password_hash="hash",
+                league_id=league.id,
+                team_type=TeamType.STUDENT,
+            )
+        )
+    db_session.commit()
+
+    # Skips 1, finds 2 (gap between 1 and 3)
+    assert next_available_team_name(db_session, "Foo") == "Foo2"
+
+
+def test_next_available_team_name_ignores_non_numeric_suffix(db_session: Session):
+    """Teams like 'FooBar' must not confuse the counter."""
+    league = db_session.exec(select(League).where(League.name == "unassigned")).first()
+    db_session.add(
+        Team(
+            name="FooBar",
+            school_name="Foo",
+            password_hash="hash",
+            league_id=league.id,
+            team_type=TeamType.STUDENT,
+        )
+    )
+    db_session.commit()
+    assert next_available_team_name(db_session, "Foo") == "Foo1"
+
+
+def test_next_available_team_name_empty_sanitized_raises(db_session: Session):
+    with pytest.raises(ValueError):
+        next_available_team_name(db_session, "")
+
+
+def test_create_school_team_integrity_retry(db_session: Session, monkeypatch):
+    """If the first commit hits IntegrityError, the counter advances and a second commit succeeds."""
+    now = datetime.now(AUSTRALIA_SYDNEY_TZ)
+    institution = db_session.exec(
+        select(Institution).where(Institution.name == "Admin Institution")
+    ).first()
+    league = League(
+        name="retry_test_league",
+        created_date=now,
+        expiry_date=now + timedelta(days=1),
+        game="greedy_pig",
+        institution_id=institution.id,
+        league_type=LeagueType.INSTITUTION,
+        school_league=True,
+        schools_config={"source": "static", "schools": ["Willetton"]},
+    )
+    db_session.add(league)
+    db_session.commit()
+    db_session.refresh(league)
+
+    original_commit = Session.commit
+    calls = {"n": 0}
+
+    def flaky_commit(self):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise IntegrityError("simulated", None, Exception("race"))
+        return original_commit(self)
+
+    monkeypatch.setattr(Session, "commit", flaky_commit)
+
+    team = create_school_team(db_session, league.id, "Willetton", "pw")
+    assert team.name == "Willetton2"
+    assert calls["n"] >= 2
+
+
+def test_create_school_team_rejects_empty_sanitized(db_session: Session):
+    league = db_session.exec(select(League).where(League.name == "unassigned")).first()
+    with pytest.raises(ValueError):
+        create_school_team(db_session, league.id, "!!!", "pw")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
       - "3000:3000"
     environment:
       - NODE_ENV=development
-      - VITE_ASSETS_URL=${VITE_ASSETS_URL:-http://localhost:9000/agent-games-assets}
+      - VITE_ASSETS_URL=${VITE_ASSETS_URL:-https://agent-games-assets.s3.ap-southeast-2.amazonaws.com}
     volumes:
       - ./frontend:/app
       - /app/node_modules
@@ -121,16 +121,9 @@ services:
     image: minio/minio:latest
     entrypoint: /bin/sh
     command: >
-      -c "mkdir -p /data/${AWS_S3_ASSETS_BUCKET:-agent-games-assets}/images
-      /data/${AWS_S3_ASSETS_BUCKET:-agent-games-assets}/logos
-      /data/${AWS_S3_ASSETS_BUCKET:-agent-games-assets}/support/institution
+      -c "mkdir -p /data/${AWS_S3_ASSETS_BUCKET:-agent-games-assets}/support/institution
       /data/${AWS_S3_ASSETS_BUCKET:-agent-games-assets}/support/user &&
-      minio server /data --console-address ':9001' &
-      MINIO_PID=$$! &&
-      until mc alias set local http://localhost:9000 $$MINIO_ROOT_USER $$MINIO_ROOT_PASSWORD >/dev/null 2>&1; do sleep 1; done &&
-      mc anonymous set download local/${AWS_S3_ASSETS_BUCKET:-agent-games-assets}/images >/dev/null 2>&1 || true &&
-      mc anonymous set download local/${AWS_S3_ASSETS_BUCKET:-agent-games-assets}/logos >/dev/null 2>&1 || true &&
-      wait $$MINIO_PID"
+      exec minio server /data --console-address ':9001'"
     ports:
       - "9000:9000"
       - "9001:9001"

--- a/frontend/src/AgentGames/About.jsx
+++ b/frontend/src/AgentGames/About.jsx
@@ -1,0 +1,154 @@
+import React from 'react';
+
+import { imageUrl, videoUrl } from '../config/assets';
+
+const About = () => {
+  return (
+    <div className="min-h-screen bg-ui-lighter pt-12">
+      {/* Hero Section */}
+      <section className="bg-gradient-to-br from-league-blue to-primary py-20">
+        <div className="container mx-auto px-6 text-center">
+          <h1 className="text-4xl md:text-6xl font-bold text-white mb-6">
+            About Agent Games
+          </h1>
+          <p className="text-xl text-league-text max-w-3xl mx-auto">
+            The story behind the platform — and how you can try it yourself.
+          </p>
+        </div>
+      </section>
+
+      {/* Story Section */}
+      <section className="py-16">
+        <div className="container mx-auto px-6">
+          <div className="max-w-xl mx-auto grid grid-cols-2 gap-4 mb-10">
+            <img
+              src={imageUrl('about/vcc1.jpeg')}
+              alt=""
+              className="w-full h-auto rounded-lg shadow-md object-cover"
+            />
+            <img
+              src={imageUrl('about/vcc2.jpeg')}
+              alt=""
+              className="w-full h-auto rounded-lg shadow-md object-cover"
+            />
+          </div>
+          <div className="max-w-3xl mx-auto space-y-5 text-ui text-lg leading-relaxed">
+            <p>
+              Hi — I'm Sanjin, a Python developer and a recovering computer
+              science teacher.
+            </p>
+            <p>
+              Agent Games is an experiment that hatched out of the{' '}
+              <strong>Victorian Coding Challenge</strong>. It's been a labour
+              of love for four years, and somewhere along the way I had so
+              much fun building it that I decided to move into programming
+              full time.
+            </p>
+            <p>
+              Every year over <strong>1,000 students</strong> take part, and
+              every game you see here was designed for the Victorian Coding
+              Challenge itself.
+            </p>
+            <p>
+              My goal from here is to get Agent Games into more universities
+              and high schools running extension programs — anywhere curious
+              students are learning to think algorithmically.
+            </p>
+            <p>
+              I'm always looking for collaborators. If you have ideas for
+              making the site better or more secure, or you'd like to design a
+              new game for the platform — <strong>get in touch</strong>.
+            </p>
+            <p>
+              There's nothing for sale here. This is, and will remain, free to
+              use.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Tutorial Section */}
+      <section className="py-16 bg-white">
+        <div className="container mx-auto px-6">
+          <h2 className="text-3xl font-bold text-ui-dark text-center mb-12">
+            Tutorial
+          </h2>
+          <div className="grid md:grid-cols-2 gap-6 max-w-5xl mx-auto">
+            {/* About Agent Games */}
+            <div className="bg-ui-lighter rounded-lg shadow-md overflow-hidden flex flex-col">
+              <div className="aspect-video bg-black">
+                <video
+                  controls
+                  preload="metadata"
+                  className="w-full h-full"
+                  src={videoUrl('about_agent_games.mp4')}
+                />
+              </div>
+              <div className="p-4">
+                <h3 className="text-xl font-semibold text-ui-dark mb-1">
+                  About Agent Games
+                </h3>
+                <p className="text-ui text-sm">
+                  A short overview of what the platform does and who it's for.
+                </p>
+              </div>
+            </div>
+
+            {/* Run Locally */}
+            <div className="bg-ui-lighter rounded-lg shadow-md overflow-hidden flex flex-col">
+              <div className="aspect-video bg-black">
+                <video
+                  controls
+                  preload="metadata"
+                  className="w-full h-full"
+                  src={videoUrl('run_locally.mp4')}
+                />
+              </div>
+              <div className="p-4">
+                <h3 className="text-xl font-semibold text-ui-dark mb-1">
+                  Run Locally in 5 min!
+                </h3>
+                <p className="text-ui text-sm">
+                  Walk-through of running Agent Games on your own machine.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Pycon Presentation Section */}
+      <section className="py-16 bg-ui-lighter">
+        <div className="container mx-auto px-6">
+          <h2 className="text-3xl font-bold text-ui-dark text-center mb-12">
+            Pycon Presentation
+          </h2>
+          <div className="max-w-3xl mx-auto">
+            <div className="bg-white rounded-lg shadow-md overflow-hidden flex flex-col">
+              <div className="aspect-video bg-black">
+                <iframe
+                  className="w-full h-full border-0"
+                  src="https://www.youtube.com/embed/GhwYsMxbvkQ"
+                  title="Pycon Presentation"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                  allowFullScreen
+                />
+              </div>
+              <div className="p-4">
+                <h3 className="text-xl font-semibold text-ui-dark mb-1">
+                  Pycon Presentation
+                </h3>
+                <p className="text-ui text-sm">
+                  Agent Games presented live at PyCon AU — the vision and the
+                  classroom results.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default About;

--- a/frontend/src/AgentGames/Shared/League/LeagueCreation.jsx
+++ b/frontend/src/AgentGames/Shared/League/LeagueCreation.jsx
@@ -14,10 +14,13 @@ const LeagueCreation = () => {
     leagueName: "",
     gameName: "",
     selectedDate: null,
+    schoolLeague: false,
+    schoolsText: "",
   });
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
   const [signupUrl, setSignupUrl] = useState("");
+  const [createdSchoolLeague, setCreatedSchoolLeague] = useState(false);
 
   const fetchGames = async () => {
     try {
@@ -59,14 +62,20 @@ const LeagueCreation = () => {
   }, []);
 
   const handleChange = (e) => {
-    const { name, value } = e.target;
+    const { name, value, type, checked } = e.target;
     setLeagueInfo((prev) => ({
       ...prev,
-      [name]: value,
+      [name]: type === "checkbox" ? checked : value,
     }));
     setError("");
     setSignupUrl(""); // Clear previous signup URL when form changes
   };
+
+  const parseSchools = (text) =>
+    text
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean);
 
   const handleDateChange = (date) => {
     setLeagueInfo((prev) => ({
@@ -86,6 +95,14 @@ const LeagueCreation = () => {
     if (!leagueInfo.gameName) {
       setError("Game selection is required");
       return false;
+    }
+
+    if (leagueInfo.schoolLeague) {
+      const schools = parseSchools(leagueInfo.schoolsText);
+      if (schools.length === 0) {
+        setError("Add at least one school (one per line)");
+        return false;
+      }
     }
 
     return true;
@@ -109,6 +126,10 @@ const LeagueCreation = () => {
           expiry_date: leagueInfo.selectedDate
             ? leagueInfo.selectedDate.toISOString()
             : undefined,
+          school_league: leagueInfo.schoolLeague,
+          schools: leagueInfo.schoolLeague
+            ? parseSchools(leagueInfo.schoolsText)
+            : [],
         }),
       });
 
@@ -123,6 +144,7 @@ const LeagueCreation = () => {
           const baseUrl = `${window.location.protocol}//${window.location.host}`;
           const signupPath = `/TeamSignup/${data.data.signup_token}`;
           setSignupUrl(`${baseUrl}${signupPath}`);
+          setCreatedSchoolLeague(Boolean(data.data.school_league));
         }
 
         // Reset form after successful creation
@@ -130,6 +152,8 @@ const LeagueCreation = () => {
           leagueName: "",
           gameName: games[0] || "",
           selectedDate: null,
+          schoolLeague: false,
+          schoolsText: "",
         });
       } else {
         setError(data.message || "Failed to create league");
@@ -182,6 +206,43 @@ const LeagueCreation = () => {
           ))}
         </select>
       </div>
+
+      <div className="mb-4 flex items-center">
+        <input
+          type="checkbox"
+          id="schoolLeague"
+          name="schoolLeague"
+          checked={leagueInfo.schoolLeague}
+          onChange={handleChange}
+          className="mr-2"
+        />
+        <label htmlFor="schoolLeague" className="text-ui-dark">
+          School league (students pick their school from a dropdown; team names
+          auto-generated; no email, no password recovery)
+        </label>
+      </div>
+
+      {leagueInfo.schoolLeague && (
+        <div className="mb-4">
+          <label htmlFor="schoolsText" className="block text-ui-dark mb-1">
+            Schools (one per line)
+          </label>
+          <textarea
+            id="schoolsText"
+            name="schoolsText"
+            rows={6}
+            value={leagueInfo.schoolsText}
+            onChange={handleChange}
+            className="w-full p-2 border border-ui-light rounded font-mono text-sm"
+            placeholder={"Willetton SHS\nPerth Modern\nApplecross SHS"}
+          />
+          <p className="text-sm text-ui mt-1">
+            Students will pick from this list at signup. At least one school is
+            required. Remind students to save their passwords &mdash; there is
+            no recovery.
+          </p>
+        </div>
+      )}
 
       <div className="mb-4">
         <label htmlFor="expiryDate" className="block text-ui-dark mb-1">
@@ -259,6 +320,13 @@ const LeagueCreation = () => {
             Teams who use this link will be directly assigned to this league
             upon signup.
           </p>
+          {createdSchoolLeague && (
+            <p className="mt-2 text-sm text-danger font-medium">
+              School league: tell students to save their passwords. There is no
+              recovery &mdash; if they lose it they will need to sign up again
+              under a new team number.
+            </p>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/AgentGames/Shared/hooks/useAuthAPI.js
+++ b/frontend/src/AgentGames/Shared/hooks/useAuthAPI.js
@@ -106,10 +106,61 @@ export const useAuthAPI = () => {
     }
   }, [apiUrl, dispatch]);
   
+  // Direct school-league signup — server assigns the team name
+  const directSchoolSignup = useCallback(async (leagueToken, schoolName, password) => {
+    setIsLoading(true);
+
+    try {
+      const response = await fetch(`${apiUrl}/user/direct-school-league-signup`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          signup_token: leagueToken,
+          school_name: schoolName,
+          password: password
+        })
+      });
+
+      const data = await response.json();
+
+      if (data.status === 'success') {
+        const decoded = jwtDecode(data.data.access_token);
+
+        dispatch(loginAction({
+          token: data.data.access_token,
+          name: data.data.team_name,
+          role: 'student',
+          exp: decoded.exp,
+          is_demo: false
+        }));
+
+        dispatch(setCurrentTeam(data.data.team_name));
+
+        toast.success(data.message || 'Signed up successfully!');
+
+        return {
+          success: true,
+          leagueId: data.data.league_id,
+          teamName: data.data.team_name
+        };
+      } else {
+        return { success: false, error: data.message || 'Failed to sign up' };
+      }
+    } catch (error) {
+      console.error('Error during school signup:', error);
+      return { success: false, error: "Network error during signup" };
+    } finally {
+      setIsLoading(false);
+    }
+  }, [apiUrl, dispatch]);
+
   return {
     isLoading,
     teamLogin,
-    directSignup
+    directSignup,
+    directSchoolSignup
   };
 };
 

--- a/frontend/src/AgentGames/User/DirectLeagueSignup.jsx
+++ b/frontend/src/AgentGames/User/DirectLeagueSignup.jsx
@@ -5,6 +5,7 @@ import { useDispatch } from "react-redux";
 import { setCurrentLeague, setLeagues } from '../../slices/leaguesSlice';
 import useAuthAPI from "../Shared/hooks/useAuthAPI";
 import useLeagueAPI from "../Shared/hooks/useLeagueAPI";
+import DirectSchoolLeagueSignup from "./DirectSchoolLeagueSignup";
 
 function DirectLeagueSignup() {
   const navigate = useNavigate();
@@ -107,6 +108,12 @@ function DirectLeagueSignup() {
           </h1>
 
           {leagueInfo ? (
+            leagueInfo.school_league ? (
+              <DirectSchoolLeagueSignup
+                leagueToken={leagueToken}
+                leagueInfo={leagueInfo}
+              />
+            ) : (
             <>
               <div className="mb-6 bg-blue-100 p-4 rounded-lg">
                 <h2 className="text-lg font-semibold text-blue-700">
@@ -202,6 +209,7 @@ function DirectLeagueSignup() {
                 </p>
               </div>
             </>
+            )
           ) : error ? (
             <div className="text-center text-red-600 p-4">
               <p>{error}</p>

--- a/frontend/src/AgentGames/User/DirectSchoolLeagueSignup.jsx
+++ b/frontend/src/AgentGames/User/DirectSchoolLeagueSignup.jsx
@@ -1,0 +1,181 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useDispatch } from "react-redux";
+import { toast } from "react-toastify";
+
+import { setCurrentLeague, setLeagues } from "../../slices/leaguesSlice";
+import useAuthAPI from "../Shared/hooks/useAuthAPI";
+
+function DirectSchoolLeagueSignup({ leagueToken, leagueInfo }) {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const { directSchoolSignup, isLoading } = useAuthAPI();
+
+  const [formData, setFormData] = useState({
+    schoolName: "",
+    password: "",
+    confirmPassword: "",
+  });
+  const [error, setError] = useState("");
+
+  const schools = leagueInfo?.schools || [];
+  const previews = leagueInfo?.team_name_previews || {};
+  const teamNamePreview = formData.schoolName
+    ? previews[formData.schoolName]
+    : "";
+
+  const handleChange = (e) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+    setError("");
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    if (!formData.schoolName) {
+      setError("Select your school");
+      return;
+    }
+    if (!formData.password) {
+      setError("Password is required");
+      return;
+    }
+    if (formData.password !== formData.confirmPassword) {
+      setError("Passwords do not match");
+      return;
+    }
+
+    const result = await directSchoolSignup(
+      leagueToken,
+      formData.schoolName,
+      formData.password
+    );
+
+    if (result.success) {
+      const leagueObject = {
+        id: result.leagueId,
+        name: leagueInfo.name,
+        game: leagueInfo.game,
+        created_date: leagueInfo.created_date,
+        expiry_date: leagueInfo.expiry_date,
+        school_league: true,
+      };
+
+      dispatch(setLeagues([leagueObject]));
+      dispatch(setCurrentLeague(leagueInfo.name));
+
+      toast.success(`Signed up as ${result.teamName}. Save your password!`);
+
+      setTimeout(() => {
+        navigate("/AgentSubmission");
+      }, 300);
+    } else {
+      setError(result.error || "Failed to sign up");
+    }
+  };
+
+  return (
+    <>
+      <div className="mb-6 bg-blue-100 p-4 rounded-lg">
+        <h2 className="text-lg font-semibold text-blue-700">
+          Joining League: {leagueInfo.name}
+        </h2>
+        <p className="text-gray-700">Game: {leagueInfo.game}</p>
+      </div>
+
+      <div
+        className="mb-6 bg-yellow-50 border-l-4 border-yellow-400 text-yellow-800 p-4 rounded"
+        role="alert"
+      >
+        <p className="font-bold">Save your password now.</p>
+        <p className="text-sm mt-1">
+          There is no password recovery. If you lose your password you will
+          need to sign up again and pick the next team number for your school.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label htmlFor="schoolName" className="block text-ui-dark mb-1">
+            School
+          </label>
+          <select
+            id="schoolName"
+            name="schoolName"
+            value={formData.schoolName}
+            onChange={handleChange}
+            className="w-full p-2 border border-ui-light rounded"
+          >
+            <option value="">Select your school...</option>
+            {schools.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {teamNamePreview && (
+          <div className="bg-blue-50 p-3 rounded text-sm">
+            Your team name will be:{" "}
+            <strong className="font-mono">{teamNamePreview}</strong>
+            <span className="text-ui ml-2">
+              (the number may change if others sign up first)
+            </span>
+          </div>
+        )}
+
+        <div>
+          <label htmlFor="password" className="block text-ui-dark mb-1">
+            Password
+          </label>
+          <input
+            type="password"
+            id="password"
+            name="password"
+            value={formData.password}
+            onChange={handleChange}
+            className="w-full p-2 border border-ui-light rounded"
+            placeholder="Choose a password"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="confirmPassword" className="block text-ui-dark mb-1">
+            Confirm Password
+          </label>
+          <input
+            type="password"
+            id="confirmPassword"
+            name="confirmPassword"
+            value={formData.confirmPassword}
+            onChange={handleChange}
+            className="w-full p-2 border border-ui-light rounded"
+            placeholder="Confirm your password"
+          />
+        </div>
+
+        {error && <div className="text-red-600">{error}</div>}
+
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="w-full py-2 px-4 bg-blue-600 hover:bg-blue-700 text-white rounded transition-colors disabled:bg-gray-400"
+        >
+          {isLoading ? "Signing up..." : "Sign Up & Join League"}
+        </button>
+      </form>
+
+      <div className="mt-4 text-center text-gray-600">
+        <p>
+          Already have a team?{" "}
+          <a href="/AgentLogin" className="text-blue-600">
+            Log in
+          </a>
+        </p>
+      </div>
+    </>
+  );
+}
+
+export default DirectSchoolLeagueSignup;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -27,6 +27,7 @@ import "react-toastify/dist/ReactToastify.css";
 import { toggleTooltips } from "./slices/settingsSlice";
 import DockerStatus from "./AgentGames/Admin/DockerStatus";
 import Demo from './AgentGames/Demo';
+import About from './AgentGames/About';
 // import AdminDemoUsers from "./AgentGames/Admin/AdminDemoUsers";
 import DirectLeagueSignup from "./AgentGames/User/DirectLeagueSignup";
 import SupportButton from "./AgentGames/Support/SupportButton";
@@ -52,6 +53,7 @@ function App() {
           <Route path="Demo" element={<Demo />} />
           <Route path="Institutions" element={<Institutions />} />
           <Route path="Leaderboards" element={<Leaderboards />} />
+          <Route path="About" element={<About />} />
           <Route
             path="/TeamSignup/:leagueToken"
             element={<DirectLeagueSignup />}

--- a/frontend/src/Navbar.jsx
+++ b/frontend/src/Navbar.jsx
@@ -142,6 +142,9 @@ function AgentGamesNavbar() {
                 <Link to="/Leaderboards" className={navLinkClasses}>
                   Leaderboards
                 </Link>
+                <Link to="/About" className={navLinkClasses}>
+                  About
+                </Link>
                 <Link to="/AgentLogin" className={navLinkClasses}>
                   Player Login
                 </Link>

--- a/frontend/src/config/assets.js
+++ b/frontend/src/config/assets.js
@@ -1,8 +1,10 @@
-const rawBase = import.meta.env.VITE_ASSETS_URL || "http://localhost:9000/agent-games-assets";
+const rawBase = import.meta.env.VITE_ASSETS_URL || "https://agent-games-assets.s3.ap-southeast-2.amazonaws.com";
 const ASSETS_URL = rawBase.replace(/\/+$/, "");
 
 export const imageUrl = (path) => `${ASSETS_URL}/images/${String(path).replace(/^\/+/, "")}`;
 
 export const logoUrl = (path) => `${ASSETS_URL}/logos/${String(path).replace(/^\/+/, "")}`;
+
+export const videoUrl = (path) => `${ASSETS_URL}/videos/${String(path).replace(/^\/+/, "")}`;
 
 export default ASSETS_URL;

--- a/frontend/src/slices/leaguesSlice.js
+++ b/frontend/src/slices/leaguesSlice.js
@@ -25,6 +25,7 @@ const leaguesSlice = createSlice({
         name: league.name,
         signup_link: league.signup_link,
         institution_name: league.institution_name ?? null,
+        school_league: league.school_league ?? false,
       }));
       const existing = state.currentLeague
         ? state.list.find(l => l.name === state.currentLeague.name)
@@ -47,6 +48,7 @@ const leaguesSlice = createSlice({
         name: league.name,
         signup_link: league.signup_link,
         institution_name: league.institution_name ?? null,
+        school_league: league.school_league ?? false,
       });
     },
     updateExpiryDate: (state, action) => {


### PR DESCRIPTION
## Summary                                                                                                                      
                                                                                                                                                                                                                          
Adds a "school league" mode alongside the existing signup flow. When a league is created with the new `school_league` flag, students sign up by picking their school from a dropdown instead of typing a team name. Team  
names are auto-generated as `{SanitizedSchool}{N}` (e.g. `WillettonSHS1`, `WillettonSHS2`), no email is collected, and a prominent "save your password, no recovery" warning is shown. The non-school flow is untouched.  
                                                                                                                                                                                                                          
The schools list is stored per-league as JSON behind a small provider abstraction so a Google Sheets-backed provider can slot in later without another schema change.                                                     

## ⚠️  Migration required before/after deploy                                                                                                                                                                              
                
This branch adds two columns to `league`. `init_db.py` only does `create_all`, so existing DBs do NOT pick up the new columns automatically.                                                                              
                
Run once against prod Postgres:                                                                                                                                                                                           
                
ssh root@api.agentgames.io 'docker exec -i $(docker ps -qf name=agent_games-postgres) psql -U postgres -d agent_games' < backend/docker_utils/migrations/2026-04-19_school_leagues.sql                                    

Idempotent (`ADD COLUMN IF NOT EXISTS`), safe to rerun. Can be applied before the deploy for zero downtime (additive, backward-compatible), or after (league endpoints will 500 until it runs).                           
                                                                                                                                                                                                                          
## Changes
                                                                                                                                                                                                                          
**Backend**     
- `League.school_league: bool` + `schools_config: JSON` columns.
- `backend/schools/providers.py` — `SchoolsProvider` protocol + `StaticSchoolsProvider`; future Sheets provider is a new `elif` branch.                                                                                   
- `backend/routes/user/team_naming.py` — sanitization, next-available-N lookup, race-safe `create_school_team` with retry on `IntegrityError`.                                                                            
- `LeagueSignUp` takes `school_league` + `schools` (deduped/stripped; punctuation-only rejected).                                                                                                                         
- `GET /user/league-info/{token}` returns `school_league`, schools list, and `team_name_previews`.                                                                                                                        
- New `POST /user/direct-school-league-signup` — validates the league is a school league and the school is whitelisted, then delegates to `create_school_team`.                                                           
                                                                                                                                                                                                                          
**Frontend**                                                                                                                                                                                                              
- `LeagueCreation.jsx` — "School league" checkbox + conditional schools textarea.                                                                                                                                         
- New `DirectSchoolLeagueSignup.jsx` — school dropdown, password warning, team-name preview.                                                                                                                              
- `DirectLeagueSignup.jsx` dispatches to the school variant when `leagueInfo.school_league` is true. Single `/TeamSignup/:token` URL.                                                                                     
- `useAuthAPI.directSchoolSignup()`, `leaguesSlice` propagates the flag.                                                                                                                                                  
                                                                                                                                                                                                                          
## Counter caveat (by design)                                                                                                                                                                                             
                                                                                                                                                                                                                          
`Team.name` is globally unique, so the counter finds the next globally-unused `{SanitizedSchool}{N}`. In practice this matches per-league counting; if the same sanitized school appears across leagues, N skips past the 
taken numbers. Documented in `team_naming.py`.
                                                                                                                                                                                                                          
## Test plan    

- [x] Backend: 33 new tests green (6 creation, 10 signup, 13 team-naming units, 4 regressions). Full suite: 451 passed.                                                                                                   
- [x] Apply migration SQL to prod Postgres.
- [x] Manual UI: create a school league, open signup URL in incognito, sign up two students for the same school, confirm `WillettonSHS1` / `WillettonSHS2`.                                                               
- [x] Regression: create a non-school league, confirm the classic signup form renders and works.                                                                                                                          
- [x] Team login with a school-league-generated team name + password wor