### PR TITLE
Frontend game streamlining

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A multi-game agent simulation platform where students and teams submit code agents that compete in game simulations.
 
+> **Adding a new game?** See **[backend/games/README.md](backend/games/README.md)** — drop 3 files in `backend/games/<name>/` and 1 manifest folder in `frontend/src/AgentGames/Feedback/games/<name>/`. Auto-discovered on both sides.
+
 ## Frontend
 
 ![React](https://img.shields.io/badge/React-19.2.4-61DAFB?logo=react&logoColor=white)
@@ -63,6 +65,12 @@ DATABASE_URL=postgresql+psycopg://postgres:<real password>@postgres:5432/agent_g
 ```
 
 Remove the `command:` line from the `api` service in `docker-compose.yml` to switch from dev uvicorn to gunicorn with 3 workers.
+
+## Adding a New Game
+
+Games are auto-discovered from `backend/games/*/` and `frontend/src/AgentGames/Feedback/games/*/`. Drop the required files, restart services, and the new game lights up across the API, validator, simulator, league dropdown, homepage, demo, and feedback rendering — no edits to factories, registries, or config.
+
+**Full walkthrough:** [backend/games/README.md](backend/games/README.md)
 
 ## Service Management
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -42,7 +42,30 @@ load_dotenv(os.path.join(PROJECT_ROOT, ".env"))
 CURRENT_DB = os.path.join(ROOT_DIR, "teams.db")
 GUEST_LEAGUE_EXPIRY = 24  # hours
 ADMIN_LEAGUE_EXPIRY = 180  # 1 week and 12 hours
-GAMES = ["greedy_pig", "prisoners_dilemma", "lineup4", "arena_champions"]
+
+
+def _discover_games(games_dir):
+    """Scan backend/games/ for valid game folders.
+
+    A folder counts as a game when it contains all three required files:
+    player.py, <folder_name>.py, validation_players.py.
+    """
+    if not os.path.isdir(games_dir):
+        return []
+    games = []
+    for entry in sorted(os.listdir(games_dir)):
+        game_dir = os.path.join(games_dir, entry)
+        if not os.path.isdir(game_dir):
+            continue
+        if entry.startswith("_") or entry.startswith("."):
+            continue
+        required = ["player.py", f"{entry}.py", "validation_players.py"]
+        if all(os.path.isfile(os.path.join(game_dir, f)) for f in required):
+            games.append(entry)
+    return games
+
+
+GAMES = _discover_games(os.path.join(ROOT_DIR, "games"))
 
 
 def get_service_url(service_name, endpoint=None):

--- a/backend/games/README.md
+++ b/backend/games/README.md
@@ -1,0 +1,112 @@
+# Adding a New Game
+
+Games are auto-discovered. Drop the right files in the right folders and they light up — no edits to `config.py`, `game_factory.py`, or any frontend registry needed.
+
+## Backend — 3 files in `backend/games/<game_name>/`
+
+Folder name **is** the game's identifier (snake_case, used in URLs, league records, and feedback payloads). The folder must contain exactly these three files:
+
+| File | Purpose |
+|------|---------|
+| `player.py` | Abstract `Player` base class students subclass |
+| `<game_name>.py` | Game class extending `BaseGame` — must contain exactly one `BaseGame` subclass |
+| `validation_players.py` | Sample players used by the validator to test submissions |
+
+An `__init__.py` is optional (most existing games have an empty one — fine either way).
+
+### `player.py`
+
+```python
+from abc import ABC, abstractmethod
+
+
+class Player(ABC):
+    def __init__(self):
+        self.name = self.__class__.__name__
+        self.feedback = []
+
+    def add_feedback(self, message):
+        self.feedback.append(message)
+
+    @abstractmethod
+    def make_decision(self, game_state):
+        pass
+```
+
+### `<game_name>.py`
+
+Subclass `BaseGame`. Set `game_instructions` (HTML shown in editor) and `starter_code` (skeleton students see). Implement `play_game` and `run_simulations`. See `greedy_pig/greedy_pig.py` for a minimal worked example.
+
+Return dict from `run_simulations` must include `total_points` and `num_simulations`; optional `table` keys become extra columns in the default results display.
+
+### `validation_players.py`
+
+Module-level `players = [Instance1(), Instance2(), ...]` — the validator runs new submissions against this list.
+
+```python
+from backend.games.<game_name>.player import Player
+
+class Simple(Player):
+    def make_decision(self, game_state):
+        return ...
+
+players = [Simple()]
+```
+
+### Discovery
+
+`backend/config.py::_discover_games` scans `backend/games/*/` and accepts any folder containing all three files. `GameFactory.get_game_class(name)` imports `backend.games.<name>.<name>` and returns the single `BaseGame` subclass it finds.
+
+## Frontend — 1 folder in `frontend/src/AgentGames/Feedback/games/<game_name>/`
+
+The folder must export a manifest at `index.jsx`:
+
+```jsx
+import MyGameFeedback from './MyGameFeedback';
+
+export default {
+  name: 'my_game',                     // must match backend folder name
+  displayName: 'My Game',              // shown on cards and headings
+  description: 'Long blurb for the homepage card.',
+  shortDescription: 'Tight blurb for the demo panel.',  // optional
+  thumbnail: 'games/my_game.png',      // S3 path under VITE_ASSETS_URL/images/
+  featured: true,                      // show on AgentHome + Demo
+  order: 5,                            // sort key for card grids
+  Feedback: MyGameFeedback,            // component receives { feedback }
+  ResultsDisplay: null,                // optional; null = default ResultsDisplay
+};
+```
+
+`frontend/src/AgentGames/Feedback/games/index.jsx` collects every subfolder's `index.jsx` via `import.meta.glob`. The collected map drives:
+
+- **`FeedbackRegistry`** — looks up `Feedback` component by `feedback.game`
+- **`GameResultsWrapper`** — looks up optional `ResultsDisplay` by `currentLeague.game`
+- **`AgentHome` + `Demo`** — iterate `featuredGames` to render the card grids
+
+### Feedback component
+
+Receives one prop: `feedback` (the dict the game emits in `game_feedback`). Game feedback payloads must include `game: '<game_name>'` so the registry routes them — `BaseGame` already sets this for you.
+
+### Optional `ResultsDisplay`
+
+Only override when the default `Shared/Utilities/ResultsDisplay` table doesn't fit (e.g. lineup4 wins/losses, arena champions per-round scoring). See `lineup4/Lineup4ResultsDisplay.jsx`.
+
+### Thumbnail
+
+Upload PNG to S3 (or whatever `VITE_ASSETS_URL` points at) under `images/games/<game_name>.png`. The manifest's `thumbnail` field is passed straight to `imageUrl(...)`.
+
+## End-to-end checklist for a new game
+
+1. `mkdir backend/games/my_game/`
+2. Add `player.py`, `my_game.py`, `validation_players.py`
+3. Restart API + validator + simulator (Docker picks up the new files; no `game_factory` edit)
+4. `mkdir frontend/src/AgentGames/Feedback/games/my_game/`
+5. Add `MyGameFeedback.jsx` and `index.jsx`
+6. Upload `images/games/my_game.png` to assets bucket
+7. Reload the frontend — homepage card, demo panel, league dropdown, feedback rendering all light up
+
+## Notes
+
+- `backend/games/game_instructions.md` is the older walkthrough — kept for reference but predates auto-discovery. Trust this README.
+- Tests run via Docker compose — see top-level `CLAUDE.md`.
+- Game-name convention: snake_case folder, matching `.py` module name, matching `feedback.game` string. Don't drift.

--- a/backend/games/game_factory.py
+++ b/backend/games/game_factory.py
@@ -1,19 +1,43 @@
-from backend.games.greedy_pig.greedy_pig import GreedyPigGame
-from backend.games.prisoners_dilemma.prisoners_dilemma import PrisonersDilemmaGame
+import importlib
+import inspect
+
+from backend.config import GAMES
+from backend.games.base_game import BaseGame
 
 
 class GameFactory:
+    _cache = {}
+
     @staticmethod
     def get_game_class(game_name):
-        if game_name == "greedy_pig":
-            return GreedyPigGame
-        elif game_name == "prisoners_dilemma":
-            return PrisonersDilemmaGame
-        elif game_name == "lineup4":
-            from backend.games.lineup4.lineup4 import Lineup4Game
-            return Lineup4Game
-        elif game_name == "arena_champions":
-            from backend.games.arena_champions.arena_champions import ArenaChampionsGame
-            return ArenaChampionsGame
-        else:
+        """Dynamically resolve a game's BaseGame subclass by folder name.
+
+        Convention: backend/games/<game_name>/<game_name>.py must define
+        exactly one subclass of BaseGame.
+        """
+        if game_name in GameFactory._cache:
+            return GameFactory._cache[game_name]
+
+        if game_name not in GAMES:
             raise ValueError(f"Unknown game: {game_name}")
+
+        try:
+            module = importlib.import_module(
+                f"backend.games.{game_name}.{game_name}"
+            )
+        except ModuleNotFoundError as e:
+            raise ValueError(f"Unknown game: {game_name}") from e
+
+        for attr in vars(module).values():
+            if (
+                inspect.isclass(attr)
+                and issubclass(attr, BaseGame)
+                and attr is not BaseGame
+                and attr.__module__ == module.__name__
+            ):
+                GameFactory._cache[game_name] = attr
+                return attr
+
+        raise ValueError(
+            f"No BaseGame subclass found in backend.games.{game_name}.{game_name}"
+        )

--- a/backend/tests/games/test_game_discovery.py
+++ b/backend/tests/games/test_game_discovery.py
@@ -1,0 +1,174 @@
+import importlib
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+from backend.config import GAMES, ROOT_DIR, _discover_games
+from backend.games.base_game import BaseGame
+from backend.games.game_factory import GameFactory
+
+GAMES_DIR = Path(ROOT_DIR) / "games"
+
+
+# ---------------------------------------------------------------------------
+# _discover_games — pure filesystem scan
+# ---------------------------------------------------------------------------
+
+
+def test_discover_returns_known_games():
+    found = _discover_games(str(GAMES_DIR))
+    for name in ("greedy_pig", "prisoners_dilemma", "lineup4", "arena_champions"):
+        assert name in found
+
+
+def test_discover_is_sorted():
+    found = _discover_games(str(GAMES_DIR))
+    assert found == sorted(found)
+
+
+def test_discover_matches_config_GAMES():
+    assert set(GAMES) == set(_discover_games(str(GAMES_DIR)))
+
+
+def test_discover_missing_dir_returns_empty(tmp_path):
+    assert _discover_games(str(tmp_path / "does_not_exist")) == []
+
+
+def _make_game(root, name, files):
+    d = root / name
+    d.mkdir()
+    for f in files:
+        (d / f).write_text("")
+
+
+def test_discover_requires_all_three_files(tmp_path):
+    _make_game(tmp_path, "complete", ["player.py", "complete.py", "validation_players.py"])
+    _make_game(tmp_path, "missing_player", ["complete.py", "validation_players.py"])
+    _make_game(tmp_path, "missing_main", ["player.py", "validation_players.py"])
+    _make_game(tmp_path, "missing_validation", ["player.py", "missing_validation.py"])
+    _make_game(
+        tmp_path,
+        "wrong_main_name",
+        ["player.py", "other_name.py", "validation_players.py"],
+    )
+    found = _discover_games(str(tmp_path))
+    assert found == ["complete"]
+
+
+def test_discover_ignores_underscore_and_hidden_prefixes(tmp_path):
+    _make_game(tmp_path, "_private", ["player.py", "_private.py", "validation_players.py"])
+    _make_game(tmp_path, ".hidden", ["player.py", ".hidden.py", "validation_players.py"])
+    _make_game(tmp_path, "real", ["player.py", "real.py", "validation_players.py"])
+    found = _discover_games(str(tmp_path))
+    assert found == ["real"]
+
+
+def test_discover_ignores_loose_files(tmp_path):
+    (tmp_path / "stray.py").write_text("")
+    _make_game(tmp_path, "real", ["player.py", "real.py", "validation_players.py"])
+    found = _discover_games(str(tmp_path))
+    assert found == ["real"]
+
+
+# ---------------------------------------------------------------------------
+# GameFactory.get_game_class — dynamic import + BaseGame reflection
+# ---------------------------------------------------------------------------
+
+
+def test_factory_returns_known_game_class():
+    cls = GameFactory.get_game_class("greedy_pig")
+    assert cls.__name__ == "GreedyPigGame"
+    assert issubclass(cls, BaseGame)
+
+
+def test_factory_unknown_game_raises():
+    with pytest.raises(ValueError, match="Unknown game"):
+        GameFactory.get_game_class("not_a_real_game_xyz")
+
+
+def test_factory_caches_result():
+    a = GameFactory.get_game_class("greedy_pig")
+    b = GameFactory.get_game_class("greedy_pig")
+    assert a is b
+
+
+# ---------------------------------------------------------------------------
+# GameFactory — temp game folder fixtures for negative / positive dynamic cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def temp_game_folder(monkeypatch):
+    """Create temp game folder(s) inside backend/games/ and clean up after."""
+    created = []
+
+    def _make(name, main_body):
+        game_dir = GAMES_DIR / name
+        if game_dir.exists():
+            raise RuntimeError(f"temp game folder already exists: {game_dir}")
+        game_dir.mkdir()
+        (game_dir / "__init__.py").write_text("")
+        (game_dir / "player.py").write_text("")
+        (game_dir / "validation_players.py").write_text("players = []\n")
+        (game_dir / f"{name}.py").write_text(main_body)
+        created.append(game_dir)
+        importlib.invalidate_caches()
+        # Allow factory to find the new game without restarting.
+        monkeypatch.setattr(
+            "backend.games.game_factory.GAMES",
+            list(GAMES) + [g.name for g in created],
+        )
+        return game_dir
+
+    yield _make
+
+    for game_dir in created:
+        prefix = f"backend.games.{game_dir.name}"
+        for mod in list(sys.modules):
+            if mod == prefix or mod.startswith(prefix + "."):
+                del sys.modules[mod]
+        GameFactory._cache.pop(game_dir.name, None)
+        shutil.rmtree(game_dir, ignore_errors=True)
+
+
+def test_factory_raises_when_no_basegame_subclass(temp_game_folder):
+    temp_game_folder(
+        "dummy_no_subclass_xyz",
+        "VALUE = 1\n",
+    )
+    with pytest.raises(ValueError, match="No BaseGame subclass"):
+        GameFactory.get_game_class("dummy_no_subclass_xyz")
+
+
+def test_factory_loads_dynamically_added_game(temp_game_folder):
+    temp_game_folder(
+        "dummy_valid_game_xyz",
+        (
+            "from backend.games.base_game import BaseGame\n"
+            "class DummyValidGameXyz(BaseGame):\n"
+            "    starter_code = ''\n"
+            "    game_instructions = ''\n"
+        ),
+    )
+    cls = GameFactory.get_game_class("dummy_valid_game_xyz")
+    assert cls.__name__ == "DummyValidGameXyz"
+    assert issubclass(cls, BaseGame)
+
+
+def test_factory_ignores_imported_basegame_subclasses(temp_game_folder):
+    """Only subclasses defined in the game's own module count.
+
+    The factory filters by `attr.__module__ == module.__name__` so a re-export
+    of an existing game class won't be picked up.
+    """
+    temp_game_folder(
+        "dummy_reexport_xyz",
+        (
+            "from backend.games.greedy_pig.greedy_pig import GreedyPigGame\n"
+            "ALIAS = GreedyPigGame\n"
+        ),
+    )
+    with pytest.raises(ValueError, match="No BaseGame subclass"):
+        GameFactory.get_game_class("dummy_reexport_xyz")

--- a/frontend/src/AgentGames/AgentHome.jsx
+++ b/frontend/src/AgentGames/AgentHome.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { imageUrl } from '../config/assets';
+import { featuredGames } from './Feedback/games';
 
 const Homepage = () => {
   return (
@@ -132,75 +133,29 @@ const Homepage = () => {
             Featured Games
           </h2>
           <div className="grid md:grid-cols-3 gap-8">
-            {/* Game 1 */}
-            <div className="bg-ui-lighter p-6 rounded-lg shadow-md">
-              <div className="mb-4 rounded overflow-hidden">
-                <img
-                  src={imageUrl('games/greedy_pig.png')}
-                  alt="Greedy Pig game"
-                  className="w-full h-48 object-cover"
-                />
+            {featuredGames.map((game) => (
+              <div
+                key={game.name}
+                className="bg-ui-lighter p-6 rounded-lg shadow-md"
+              >
+                <div className="mb-4 rounded overflow-hidden">
+                  <img
+                    src={imageUrl(game.thumbnail)}
+                    alt={`${game.displayName} game`}
+                    className="w-full h-48 object-cover"
+                  />
+                </div>
+                <h3 className="text-xl font-semibold text-ui-dark mb-2">
+                  {game.displayName}
+                </h3>
+                <p className="text-ui mb-4">{game.description}</p>
+                <a href={`/Demo?game=${game.name}`}>
+                  <span className="text-primary font-medium hover:text-primary-hover">
+                    Try it →
+                  </span>
+                </a>
               </div>
-              <h3 className="text-xl font-semibold text-ui-dark mb-2">
-                Greedy Pig
-              </h3>
-              <p className="text-ui mb-4">
-                A strategic game of risk and reward where players must decide
-                when to bank their points or continue rolling.
-              </p>
-              <a href="/Demo?game=greedy_pig">
-                <span className="text-primary font-medium hover:text-primary-hover">
-                  Try it →
-                </span>
-              </a>
-            </div>
-
-            {/* Game 2 */}
-            <div className="bg-ui-lighter p-6 rounded-lg shadow-md">
-              <div className="mb-4 rounded overflow-hidden">
-                <img
-                  src={imageUrl('games/prisoners_dilemma.png')}
-                  alt="Prisoner's Dilemma game"
-                  className="w-full h-48 object-cover"
-                />
-              </div>
-              <h3 className="text-xl font-semibold text-ui-dark mb-2">
-                Prisoner's Dilemma
-              </h3>
-              <p className="text-ui mb-4">
-                Classic game theory scenario where players must choose to
-                cooperate or defect, balancing individual vs. collective
-                benefit.
-              </p>
-              <a href="/Demo?game=prisoners_dilemma">
-                <span className="text-primary font-medium hover:text-primary-hover">
-                  Try it →
-                </span>
-              </a>
-            </div>
-
-            {/* Game 3 */}
-            <div className="bg-ui-lighter p-6 rounded-lg shadow-md">
-              <div className="mb-4 rounded overflow-hidden">
-                <img
-                  src={imageUrl('games/lineup4.png')}
-                  alt="Lineup4 game"
-                  className="w-full h-48 object-cover"
-                />
-              </div>
-              <h3 className="text-xl font-semibold text-ui-dark mb-2">
-                Lineup4
-              </h3>
-              <p className="text-ui mb-4">
-                Program an agent to play the classic Connect Four game,
-                requiring spatial reasoning and forward planning.
-              </p>
-              <a href="/Demo?game=lineup4">
-                <span className="text-primary font-medium hover:text-primary-hover">
-                  Try it →
-                </span>
-              </a>
-            </div>
+            ))}
           </div>
         </div>
       </section>

--- a/frontend/src/AgentGames/Demo.jsx
+++ b/frontend/src/AgentGames/Demo.jsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { toast } from 'react-toastify';
 import moment from 'moment-timezone';
 import { login } from '../slices/authSlice';
+import { featuredGames } from './Feedback/games';
 
 function Demo() {
     const navigate = useNavigate();
@@ -139,18 +140,12 @@ function Demo() {
                         <div className="bg-ui-lighter p-6 rounded-lg">
                             <h2 className="text-xl font-semibold text-ui-dark mb-4">Available Demo Games:</h2>
                             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                                <div className="bg-white p-4 rounded shadow">
-                                    <h3 className="font-medium text-lg">Greedy Pig</h3>
-                                    <p className="text-sm text-ui">A risk/reward dice game. When do you bank your points?</p>
-                                </div>
-                                <div className="bg-white p-4 rounded shadow">
-                                    <h3 className="font-medium text-lg">Prisoner's Dilemma</h3>
-                                    <p className="text-sm text-ui">The classic cooperation vs. betrayal game theory problem.</p>
-                                </div>
-                                <div className="bg-white p-4 rounded shadow">
-                                    <h3 className="font-medium text-lg">Lineup4</h3>
-                                    <p className="text-sm text-ui">The strategic game of connecting four pieces in a row.</p>
-                                </div>
+                                {featuredGames.map((game) => (
+                                    <div key={game.name} className="bg-white p-4 rounded shadow">
+                                        <h3 className="font-medium text-lg">{game.displayName}</h3>
+                                        <p className="text-sm text-ui">{game.shortDescription || game.description}</p>
+                                    </div>
+                                ))}
                             </div>
                         </div>
 

--- a/frontend/src/AgentGames/Feedback/GameResultsWrapper.jsx
+++ b/frontend/src/AgentGames/Feedback/GameResultsWrapper.jsx
@@ -1,22 +1,13 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import ResultsDisplay from "../Shared/Utilities/ResultsDisplay";
-import Lineup4ResultsDisplay from './games/lineup4/Lineup4ResultsDisplay';
+import ResultsDisplay from '../Shared/Utilities/ResultsDisplay';
+import { getGame } from './games';
 
 const GameResultsWrapper = (props) => {
     const currentLeague = useSelector((state) => state.leagues.currentLeague);
-
-    // Determine which display component to use based on the game
-    const getResultsDisplay = () => {
-        if (currentLeague && currentLeague.game === 'lineup4') {
-            return <Lineup4ResultsDisplay {...props} />;
-        }
-
-        // Default to the original ResultsDisplay for other games
-        return <ResultsDisplay {...props} />;
-    };
-
-    return getResultsDisplay();
+    const game = currentLeague ? getGame(currentLeague.game) : null;
+    const Display = game?.ResultsDisplay || ResultsDisplay;
+    return <Display {...props} />;
 };
 
 export default GameResultsWrapper;

--- a/frontend/src/AgentGames/Feedback/games/arena_champions/index.jsx
+++ b/frontend/src/AgentGames/Feedback/games/arena_champions/index.jsx
@@ -1,0 +1,16 @@
+import ArenaChampionsFeedback from './ArenaChampionsFeedback';
+import ArenaChampionsResultsDisplay from './ArenaChampionsResultsDisplay';
+
+export default {
+  name: 'arena_champions',
+  displayName: 'Arena Champions',
+  description:
+    'Build a champion that picks stats, attacks, and abilities to outlast rivals across a tournament of arena battles.',
+  shortDescription:
+    'Pick stats and attacks to outlast rivals across arena battles.',
+  thumbnail: 'games/arena_champions.png',
+  featured: false,
+  order: 4,
+  Feedback: ArenaChampionsFeedback,
+  ResultsDisplay: ArenaChampionsResultsDisplay,
+};

--- a/frontend/src/AgentGames/Feedback/games/greedy_pig/index.jsx
+++ b/frontend/src/AgentGames/Feedback/games/greedy_pig/index.jsx
@@ -1,0 +1,14 @@
+import GreedyPigFeedback from './GreedyPigFeedback';
+
+export default {
+  name: 'greedy_pig',
+  displayName: 'Greedy Pig',
+  description:
+    'A strategic game of risk and reward where players must decide when to bank their points or continue rolling.',
+  shortDescription: 'A risk/reward dice game. When do you bank your points?',
+  thumbnail: 'games/greedy_pig.png',
+  featured: true,
+  order: 1,
+  Feedback: GreedyPigFeedback,
+  ResultsDisplay: null,
+};

--- a/frontend/src/AgentGames/Feedback/games/index.jsx
+++ b/frontend/src/AgentGames/Feedback/games/index.jsx
@@ -1,0 +1,24 @@
+// Auto-collected per-game manifest.
+// Drop a folder with an `index.jsx` exporting the standard shape
+// ({ name, displayName, description, thumbnail, Feedback, ResultsDisplay, ... })
+// and it lights up everywhere that imports from here.
+
+const modules = import.meta.glob('./*/index.jsx', { eager: true });
+
+const games = Object.values(modules)
+  .map((m) => m.default)
+  .filter(Boolean);
+
+export const gamesByName = Object.fromEntries(
+  games.map((g) => [g.name, g])
+);
+
+export const gamesList = [...games].sort(
+  (a, b) => (a.order ?? 999) - (b.order ?? 999)
+);
+
+export const featuredGames = gamesList.filter((g) => g.featured);
+
+export const getGame = (name) => gamesByName[name] || null;
+
+export default gamesByName;

--- a/frontend/src/AgentGames/Feedback/games/lineup4/index.jsx
+++ b/frontend/src/AgentGames/Feedback/games/lineup4/index.jsx
@@ -1,0 +1,16 @@
+import Lineup4Feedback from './Lineup4Feedback';
+import Lineup4ResultsDisplay from './Lineup4ResultsDisplay';
+
+export default {
+  name: 'lineup4',
+  displayName: 'Lineup4',
+  description:
+    'Program an agent to play the classic Connect Four game, requiring spatial reasoning and forward planning.',
+  shortDescription:
+    'The strategic game of connecting four pieces in a row.',
+  thumbnail: 'games/lineup4.png',
+  featured: true,
+  order: 3,
+  Feedback: Lineup4Feedback,
+  ResultsDisplay: Lineup4ResultsDisplay,
+};

--- a/frontend/src/AgentGames/Feedback/games/prisoners_dilemma/index.jsx
+++ b/frontend/src/AgentGames/Feedback/games/prisoners_dilemma/index.jsx
@@ -1,0 +1,15 @@
+import PrisonersFeedback from './PrisonersFeedback';
+
+export default {
+  name: 'prisoners_dilemma',
+  displayName: "Prisoner's Dilemma",
+  description:
+    'Classic game theory scenario where players must choose to cooperate or defect, balancing individual vs. collective benefit.',
+  shortDescription:
+    'The classic cooperation vs. betrayal game theory problem.',
+  thumbnail: 'games/prisoners_dilemma.png',
+  featured: true,
+  order: 2,
+  Feedback: PrisonersFeedback,
+  ResultsDisplay: null,
+};

--- a/frontend/src/AgentGames/Feedback/utils/FeedbackRegistry.jsx
+++ b/frontend/src/AgentGames/Feedback/utils/FeedbackRegistry.jsx
@@ -1,28 +1,14 @@
 import MarkdownFeedback from '../types/MarkdownFeedback';
 import JsonFeedback from '../types/JsonFeedback';
-import PrisonersFeedback from '../games/prisoners_dilemma/PrisonersFeedback';
-import Lineup4Feedback from '../games/lineup4/Lineup4Feedback';
-import ArenaChampionsFeedback from '../games/arena_champions/ArenaChampionsFeedback';
-import GreedyPigFeedback from '../games/greedy_pig/GreedyPigFeedback';
+import { getGame } from '../games';
 
 export const getFeedbackComponent = (feedback) => {
-    // Handle game-specific feedback
     if (typeof feedback === 'object' && feedback?.game) {
-        switch (feedback.game) {
-            case 'prisoners_dilemma':
-                return PrisonersFeedback;
-            case 'lineup4':
-                return Lineup4Feedback;
-            case 'arena_champions':
-                return ArenaChampionsFeedback;
-            case 'greedy_pig':
-                return GreedyPigFeedback;
-            default:
-                return JsonFeedback;
-        }
+        const game = getGame(feedback.game);
+        if (game?.Feedback) return game.Feedback;
+        return JsonFeedback;
     }
 
-    // Handle generic feedback types
     if (typeof feedback === 'string') {
         return MarkdownFeedback;
     }

--- a/frontend/src/slices/gamesSlice.js
+++ b/frontend/src/slices/gamesSlice.js
@@ -1,7 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 const initialState = {
-  list: ['Greedy Pig'],
+  list: [],
   currentGame: null,
 };
 


### PR DESCRIPTION
# Streamline game creation — auto-discovery on both sides

## Summary

Adding a new game used to mean editing six unrelated files (`config.py`, `game_factory.py`, `FeedbackRegistry.jsx`, `GameResultsWrapper.jsx`, `AgentHome.jsx`, `Demo.jsx`). After this PR, both backend and frontend auto-discover games from convention-driven folder layouts. Adding a game is now: drop 3 files in `backend/games/<name>/`, drop 1 manifest folder in `frontend/src/AgentGames/Feedback/games/<name>/`, upload a thumbnail. No edits to registries, factories, or config.

## Changes

**Backend**
- `backend/config.py` — `GAMES` derived from `_discover_games()` filesystem scan (folder must contain `player.py`, `<name>.py`, `validation_players.py`).
- `backend/games/game_factory.py` — dynamic. Imports `backend.games.<name>.<name>` and reflects to find the single `BaseGame` subclass. Cached. Hardcoded `if/elif` chain gone.

**Frontend**
- `frontend/src/AgentGames/Feedback/games/<game>/index.jsx` — per-game manifest exporting `{ name, displayName, description, shortDescription, thumbnail, featured, order, Feedback, ResultsDisplay }`. Added for all 4 existing games.
- `frontend/src/AgentGames/Feedback/games/index.jsx` — central collector via `import.meta.glob('./*/index.jsx', { eager: true })`. Exposes `gamesByName`, `gamesList`, `featuredGames`, `getGame(name)`.
- `FeedbackRegistry.jsx` — switch replaced with `getGame(feedback.game)?.Feedback` lookup.
- `GameResultsWrapper.jsx` — lineup4 special case replaced with `getGame(currentLeague.game)?.ResultsDisplay || ResultsDisplay`.
- `AgentHome.jsx` + `Demo.jsx` — hardcoded game cards (~120 lines) replaced with `featuredGames.map(...)`.
- `slices/gamesSlice.js` — stale initial state `['Greedy Pig']` → `[]`.

**Docs**
- `backend/games/README.md` — canonical add-a-game guide covering backend + frontend + thumbnail upload.
- `README.md` — top-of-file callout + dedicated "Adding a New Game" section linking the guide.

**Tests**
- `backend/tests/games/test_game_discovery.py` — 13 tests covering `_discover_games` (required files, sorting, hidden-prefix exclusion, missing-dir handling, loose-file handling) and `GameFactory.get_game_class` (known game, unknown game, cache hit, missing subclass, dynamically added game, imported-vs-defined subclass filter).

## Test plan

- [x] All 474 existing backend tests pass
- [x] 13 new discovery tests pass
- [x] Manual: existing 4 games render feedback + results table unchanged in local dev
- [ ] Verify after merge: production frontend build picks up `import.meta.glob` at runtime

## Migration notes

- No DB changes.
- No API contract changes — `/user/get-available-games` and `/user/get-game-instructions` payloads identical.
- Legacy `backend/games/game_instructions.md` left in place but flagged as outdated in the new README.