### PR TITLE
hint contex first commit

### DIFF
--- a/backend/routes/ai/hint_context.py
+++ b/backend/routes/ai/hint_context.py
@@ -1,0 +1,437 @@
+"""Builds the context string fed to the AI when generating a student hint.
+
+The validator (``backend/docker_utils/services/validation_server.py``) runs a
+student submission and returns a ``ValidationResponse`` shaped like::
+
+    {
+        "status": "success" | "error",
+        "message": str | None,            # populated on error
+        "feedback": str | dict | None,    # populated on success
+        "simulation_results": dict | None,
+        "duration_ms": float | None,
+    }
+
+That response is the only signal we get about an execution. This module turns
+it into a single human-readable string suitable for an LLM prompt, surfacing
+the three deterministic signals we can derive today:
+
+    1. Did the simulation complete?   -> status == "success"
+    2. Was there a syntax error?      -> message starts with the syntax prefix
+    3. Did the agent time out?        -> message starts with the timeout prefix
+
+Runtime tracebacks and stdout are NOT yet captured by the validator (see the
+``construction_error`` / ``runtime_error`` categories below), so for those the
+context only carries the validator's short message. When the validator starts
+returning structured traceback/stdout fields, extend ``HintContext`` and
+``build_hint_context`` to include them.
+"""
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal, Optional, Union
+
+# --- Validator coupling -----------------------------------------------------
+# These mirror the literals produced in validation_server.py. We intentionally
+# do NOT import that module: importing it constructs a FastAPI app and pulls in
+# the game factory. If you change a message there, change the matching prefix
+# here. Each prefix is matched with str.startswith() against response.message.
+
+SYNTAX_ERROR_PREFIX = "Syntax error in code:"
+TIMEOUT_PREFIX = "Your agent consumes too much time"
+UNSAFE_PREFIX = "Agent code is not safe:"
+INIT_ERROR_PREFIX = "Error initializing game:"
+CONSTRUCTION_ERROR_PREFIX = "Failed to create player"
+RUNTIME_ERROR_PREFIX = "Error during simulation:"
+
+# Hard cap the validator enforces (validation_server.VALIDATION_TIMEOUT_SECONDS).
+# Kept here only for human-readable context; not used for control flow.
+VALIDATION_TIMEOUT_SECONDS = 5
+
+# Truncate very long code / feedback so the prompt stays bounded.
+MAX_CODE_CHARS = 8_000
+MAX_FEEDBACK_CHARS = 4_000
+
+# Game feedback dicts carry a per-event "blow-by-blow" log under one of these
+# keys (greedy_pig: rounds, prisoners_dilemma: pairings, lineup4: matches/moves,
+# arena_champions: battles). That log dwarfs everything else (~39k of a ~39.5k
+# feedback dict in greedy_pig) and is irrelevant to hint generation — only the
+# aggregate keys (final_results, score_aggregate, final_scores, winner, ...) are.
+# We drop these keys, plus any other oversized list, before rendering.
+LOG_FEEDBACK_KEYS = {
+    "rounds",
+    "rolls",
+    "pairings",
+    "matches",
+    "moves",
+    "battles",
+    "match_history",
+    "history",
+}
+# A list value bigger than this (JSON chars) is treated as an event log too.
+MAX_INLINE_LIST_CHARS = 500
+
+# Directory holding the per-game packages, resolved relative to this file:
+# backend/routes/ai/hint_context.py -> parents[2] == backend/ -> backend/games.
+GAMES_DIR = Path(__file__).resolve().parents[2] / "games"
+# Upper bound on the concatenated game source we attach (chars).
+MAX_GAME_CODE_CHARS = 60_000
+
+
+# --- Outcome taxonomy -------------------------------------------------------
+
+OutcomeCategory = Literal[
+    "success",
+    "syntax_error",
+    "timeout",
+    "unsafe_code",
+    "init_error",
+    "construction_error",
+    "runtime_error",
+    "unknown_error",
+]
+
+# Human-readable one-liners describing each category, shown to the model.
+_CATEGORY_DESCRIPTION: dict[str, str] = {
+    "success": "The submission ran successfully through the single game and all simulations.",
+    "syntax_error": "The code failed to parse (Python SyntaxError).",
+    "timeout": (
+        f"The agent did not finish within the {VALIDATION_TIMEOUT_SECONDS}s limit "
+        "— likely too slow or stuck in a loop."
+    ),
+    "unsafe_code": "The code used a forbidden import or function call and was rejected before running.",
+    "init_error": "The game itself failed to initialise (not necessarily the student's fault).",
+    "construction_error": (
+        "The CustomPlayer class could not be created (error while exec'ing the code, "
+        "a bad/missing CustomPlayer class, or an exception in __init__). The validator "
+        "does not yet expose the underlying traceback for this case."
+    ),
+    "runtime_error": "The code raised an exception while a game/simulation was running.",
+    "unknown_error": "Validation failed for a reason that could not be categorised.",
+}
+
+
+def classify_outcome(status: Optional[str], message: Optional[str]) -> OutcomeCategory:
+    """Map a validator (status, message) pair onto an OutcomeCategory.
+
+    Classification is driven by the message prefixes the validator emits. Order
+    matters only in that ``success`` short-circuits on status; every error
+    branch is matched by prefix and falls through to ``unknown_error``.
+    """
+    if status == "success":
+        return "success"
+
+    msg = message or ""
+    if msg.startswith(SYNTAX_ERROR_PREFIX):
+        return "syntax_error"
+    if msg.startswith(TIMEOUT_PREFIX):
+        return "timeout"
+    if msg.startswith(UNSAFE_PREFIX):
+        return "unsafe_code"
+    if msg.startswith(INIT_ERROR_PREFIX):
+        return "init_error"
+    if msg.startswith(CONSTRUCTION_ERROR_PREFIX):
+        return "construction_error"
+    if msg.startswith(RUNTIME_ERROR_PREFIX):
+        return "runtime_error"
+    return "unknown_error"
+
+
+# --- Game source loading ----------------------------------------------------
+
+
+def load_game_source(game_name: str) -> Optional[str]:
+    """Return the full source of a game package, concatenated, or None.
+
+    Reads every non-empty ``*.py`` in ``backend/games/<game_name>/`` (the game
+    module, ``player.py``, ``validation_players.py``) straight off disk — no
+    import, so submitted/game code is never executed and this module stays
+    dependency-free. ``game_name`` is sanitised and the resolved directory must
+    sit directly under ``GAMES_DIR`` (path-traversal guard).
+    """
+    # Game folder names are simple identifiers (e.g. "greedy_pig", "lineup4").
+    # Reject anything with separators / dots before touching the filesystem.
+    if not game_name or not game_name.replace("_", "").isalnum():
+        return None
+
+    game_dir = GAMES_DIR / game_name
+    if game_dir.resolve().parent != GAMES_DIR.resolve() or not game_dir.is_dir():
+        return None
+
+    parts: list[str] = []
+    for path in sorted(game_dir.glob("*.py")):
+        if path.name == "__init__.py":
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if not text.strip():
+            continue
+        parts.append(
+            f"# ===== backend/games/{game_name}/{path.name} =====\n{text.rstrip()}"
+        )
+
+    if not parts:
+        return None
+    return _truncate("\n\n".join(parts), MAX_GAME_CODE_CHARS)
+
+
+# --- Structured context -----------------------------------------------------
+
+
+@dataclass
+class HintContext:
+    """Structured, prompt-ready view of one validation outcome.
+
+    Build it with ``from_validation_response`` and render it with
+    ``build_hint_context`` (or ``str(ctx)``).
+    """
+
+    category: OutcomeCategory
+    sim_completed: bool
+    is_syntax_error: bool
+    is_timeout: bool
+    code: str
+    game_name: Optional[str] = None
+    team_name: Optional[str] = None
+    validator_message: Optional[str] = None
+    feedback: Union[str, dict, None] = None
+    simulation_results: Optional[dict] = None
+    duration_ms: Optional[float] = None
+    # Forward-looking: populated once the validator captures these. Empty today.
+    traceback: Optional[str] = None
+    stdout: Optional[str] = None
+    # Full source of the game package — attached only when the code parsed (no
+    # syntax error) and game code inclusion is enabled.
+    game_source: Optional[str] = None
+    _warnings: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_validation_response(
+        cls,
+        code: str,
+        validation_result: dict,
+        game_name: Optional[str] = None,
+        team_name: Optional[str] = None,
+        include_game_code: bool = True,
+    ) -> "HintContext":
+        """Construct from the raw JSON dict returned by the validator.
+
+        ``validation_result`` is ``response.json()`` from the POST to the
+        validator's ``/validate`` endpoint (the same dict ``user_router`` reads).
+
+        When ``include_game_code`` is set and the submission has no syntax error,
+        the full game source for ``game_name`` is loaded and attached so the AI
+        can reason about the rules/mechanics. A syntax error means the student's
+        own code did not even parse, so the game source is skipped as noise.
+        """
+        status = validation_result.get("status")
+        message = validation_result.get("message")
+        category = classify_outcome(status, message)
+        is_syntax_error = category == "syntax_error"
+
+        warnings: list[str] = []
+        if status not in ("success", "error"):
+            warnings.append(
+                f"Unexpected validator status {status!r}; treated as an error."
+            )
+
+        game_source = None
+        if include_game_code and not is_syntax_error and game_name:
+            game_source = load_game_source(game_name)
+            if game_source is None:
+                warnings.append(
+                    f"Game source for {game_name!r} could not be loaded."
+                )
+
+        return cls(
+            category=category,
+            sim_completed=(category == "success"),
+            is_syntax_error=is_syntax_error,
+            is_timeout=(category == "timeout"),
+            code=code,
+            game_name=game_name,
+            team_name=team_name,
+            validator_message=message,
+            feedback=validation_result.get("feedback"),
+            simulation_results=validation_result.get("simulation_results"),
+            duration_ms=validation_result.get("duration_ms"),
+            traceback=validation_result.get("traceback"),
+            stdout=validation_result.get("stdout"),
+            game_source=game_source,
+            _warnings=warnings,
+        )
+
+    def __str__(self) -> str:
+        return build_hint_context(self)
+
+
+# --- Rendering --------------------------------------------------------------
+
+
+def _truncate(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    omitted = len(text) - limit
+    return f"{text[:limit]}\n... [truncated {omitted} chars]"
+
+
+def _compact_feedback(feedback: dict) -> tuple[dict, list[str]]:
+    """Strip blow-by-blow event logs from a feedback dict, keep the aggregates.
+
+    Returns (compacted_dict, dropped_key_names). A key is dropped if it is a
+    known log key or its value is an oversized list.
+    """
+    compacted: dict = {}
+    dropped: list[str] = []
+    for key, value in feedback.items():
+        if key in LOG_FEEDBACK_KEYS:
+            dropped.append(key)
+            continue
+        if (
+            isinstance(value, list)
+            and len(json.dumps(value, default=str)) > MAX_INLINE_LIST_CHARS
+        ):
+            dropped.append(key)
+            continue
+        compacted[key] = value
+    return compacted, dropped
+
+
+def _render_feedback(feedback: Union[str, dict, None]) -> Optional[str]:
+    """Normalise feedback to text, dropping the per-event log to stay small.
+
+    Feedback may be markdown (str), a structured dict (most games), or a bare
+    list (verbose log). For dicts we keep only the aggregate keys; for a bare
+    list we drop the contents and just note the count.
+    """
+    if feedback is None:
+        return None
+
+    if isinstance(feedback, str):
+        text = feedback.strip()
+        return _truncate(text, MAX_FEEDBACK_CHARS) if text else None
+
+    if isinstance(feedback, list):
+        # The whole feedback object is an event log — keep only its size.
+        return f"[{len(feedback)} blow-by-blow feedback entries omitted]" if feedback else None
+
+    compacted, dropped = _compact_feedback(feedback)
+    parts: list[str] = []
+    if compacted:
+        parts.append(
+            _truncate(json.dumps(compacted, indent=2, default=str).strip(), MAX_FEEDBACK_CHARS)
+        )
+    if dropped:
+        parts.append(f"[omitted blow-by-blow logs: {', '.join(dropped)}]")
+    return "\n".join(parts) if parts else None
+
+
+def _render_sim_results(results: Optional[dict]) -> Optional[str]:
+    if not results:
+        return None
+    return _truncate(json.dumps(results, indent=2, default=str), MAX_FEEDBACK_CHARS)
+
+
+def build_hint_context(ctx: HintContext) -> str:
+    """Render a HintContext as a single formatted string for an LLM prompt.
+
+    The string is organised into labelled sections: a header, the three
+    deterministic signals the validator gives us, the validator's message /
+    traceback / stdout where available, the student's code, and any game
+    feedback or simulation results. Sections with no data are omitted.
+    """
+    lines: list[str] = ["=== STUDENT SUBMISSION HINT CONTEXT ==="]
+
+    # Header.
+    if ctx.game_name:
+        lines.append(f"Game: {ctx.game_name}")
+    if ctx.team_name:
+        lines.append(f"Team: {ctx.team_name}")
+
+    # Outcome + the three deterministic signals.
+    lines.append("")
+    lines.append("--- Outcome ---")
+    lines.append(f"Category: {ctx.category}")
+    lines.append(_CATEGORY_DESCRIPTION.get(ctx.category, ""))
+    lines.append(f"1. Simulation completed: {'yes' if ctx.sim_completed else 'no'}")
+    lines.append(f"2. Syntax error: {'yes' if ctx.is_syntax_error else 'no'}")
+    lines.append(f"3. Timed out: {'yes' if ctx.is_timeout else 'no'}")
+    if ctx.duration_ms is not None:
+        lines.append(f"Execution time: {ctx.duration_ms:.1f} ms")
+
+    # Validator message (present on every error path).
+    if ctx.validator_message:
+        lines.append("")
+        lines.append("--- Validator Message ---")
+        lines.append(ctx.validator_message.strip())
+
+    # Traceback / stdout — empty today, rendered when the validator supplies them.
+    if ctx.traceback:
+        lines.append("")
+        lines.append("--- Stack Trace ---")
+        lines.append(_truncate(ctx.traceback.strip(), MAX_FEEDBACK_CHARS))
+    if ctx.stdout:
+        lines.append("")
+        lines.append("--- Captured stdout ---")
+        lines.append(_truncate(ctx.stdout.strip(), MAX_FEEDBACK_CHARS))
+
+    # Submitted code.
+    lines.append("")
+    lines.append("--- Submitted Code ---")
+    lines.append("```python")
+    lines.append(_truncate(ctx.code.rstrip(), MAX_CODE_CHARS))
+    lines.append("```")
+
+    # Game feedback (success path, and some games emit partial feedback).
+    feedback_text = _render_feedback(ctx.feedback)
+    if feedback_text:
+        lines.append("")
+        lines.append("--- Game Feedback ---")
+        lines.append(feedback_text)
+
+    # Simulation results summary (success path).
+    sim_text = _render_sim_results(ctx.simulation_results)
+    if sim_text:
+        lines.append("")
+        lines.append("--- Simulation Results ---")
+        lines.append(sim_text)
+
+    # Any builder-level warnings.
+    if ctx._warnings:
+        lines.append("")
+        lines.append("--- Notes ---")
+        lines.extend(f"- {w}" for w in ctx._warnings)
+
+    # Full game source — bulky reference, rendered last so the outcome and the
+    # student's own code stay at the top.
+    if ctx.game_source:
+        lines.append("")
+        lines.append("--- Game Source Code ---")
+        lines.append(
+            "Full source of the game the agent plays, for rules/mechanics context:"
+        )
+        lines.append("```python")
+        lines.append(ctx.game_source)
+        lines.append("```")
+
+    return "\n".join(lines)
+
+
+def build_hint_context_from_response(
+    code: str,
+    validation_result: dict,
+    game_name: Optional[str] = None,
+    team_name: Optional[str] = None,
+    include_game_code: bool = True,
+) -> str:
+    """Convenience one-shot: raw validator dict -> formatted context string."""
+    ctx = HintContext.from_validation_response(
+        code,
+        validation_result,
+        game_name=game_name,
+        team_name=team_name,
+        include_game_code=include_game_code,
+    )
+    return build_hint_context(ctx)

--- a/backend/routes/user/user_router.py
+++ b/backend/routes/user/user_router.py
@@ -24,6 +24,7 @@ from backend.routes.institution.institution_db import (
 )
 from backend.routes.institution.institution_models import LeagueName
 from backend.routes.institution.institution_router import _resolve_institution
+from backend.routes.ai.hint_context import build_hint_context_from_response
 from backend.routes.user.user_db import (
     SubmissionLimitExceededError,
     TeamNotFoundError,
@@ -122,6 +123,20 @@ async def submit_agent(
             )
 
         validation_result = response.json()
+
+        # --- TEMP local debug: print hint context on every submission ---
+        print(
+            "\n" + "=" * 70 + "\n"
+            + build_hint_context_from_response(
+                submission.code,
+                validation_result,
+                game_name=team.league.game,
+                team_name=team_name,
+            )
+            + "\n" + "=" * 70,
+            flush=True,
+        )
+
         if validation_result.get("status") == "error":
             return ResponseModel(
                 status="error",


### PR DESCRIPTION
Standalone context builder

Saves to a text file when run locally 

tracebacks are not included as this is quite complex and involves a number of design decisions that I want to take some time to think about 

one option given that code_hint has a goal is to parse the game_instructions separately and put them in the goal portion of the hint request