### PR TITLE
Enhanced exercise

### DIFF
--- a/backend/bench_validation.py
+++ b/backend/bench_validation.py
@@ -1,0 +1,133 @@
+"""Temporary benchmark: find per-game validation simulation counts under 1s.
+
+Mirrors the body of backend/tasks/validation_task.run_validation (feedback game
++ run_simulations + get_player_strategies) using each game's starter_code as
+the submitted agent. Run inside the worker image:
+
+docker compose -f docker-compose.yml -f docker-compose.test.yml \
+    run --rm --no-deps test-runner python backend/bench_validation.py
+"""
+
+import contextlib
+import io
+import json
+import statistics
+import time
+from datetime import timedelta
+
+from backend.config import GAMES
+from backend.database.db_models import League
+from backend.games.game_factory import GameFactory
+from backend.time_utils import utc_now
+
+# Total validation budget (seconds). Keep headroom below the 1s requirement.
+BUDGET = 0.8
+FANOUT_GAMES = {"hearts", "ohhell", "thirteen"}  # 1 pass = many sub-games
+
+
+def make_instance(game_name):
+    league = League(
+        name="validation_leagueX",
+        created_date=utc_now(),
+        expiry_date=utc_now() + timedelta(days=1),
+        game=game_name,
+    )
+    game_class = GameFactory.get_game_class(game_name)
+    instance = game_class(league)
+    instance.add_player(game_class.starter_code, "bench_team")
+    return instance, league
+
+
+def timed(fn, *args, **kwargs):
+    t0 = time.perf_counter()
+    with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(
+        io.StringIO()
+    ):
+        fn(*args, **kwargs)
+    return time.perf_counter() - t0
+
+
+def full_validation(game_name, n_sims):
+    """The exact run_validation body, timed like its duration_ms."""
+    instance, league = make_instance(game_name)
+    t0 = time.perf_counter()
+    with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(
+        io.StringIO()
+    ):
+        instance.run_single_game_with_feedback(None)
+        instance.reset()
+        results = instance.run_simulations(n_sims, league, None)
+        results["strategies"] = instance.get_player_strategies()
+    return time.perf_counter() - t0, results.get("num_simulations")
+
+
+def bench_game(game_name):
+    instance, league = make_instance(game_name)
+    n_players = len(instance.players)
+
+    # Warmup (imports, first-run costs)
+    timed(instance.run_single_game_with_feedback, None)
+    instance.reset()
+
+    feedback_times = []
+    for _ in range(3):
+        feedback_times.append(timed(instance.run_single_game_with_feedback, None))
+        instance.reset()
+    feedback_med = statistics.median(feedback_times)
+
+    # Per-simulation cost: grow N until the batch takes >= 0.2s
+    n = 1
+    while True:
+        elapsed = timed(instance.run_simulations, n, league, None)
+        if elapsed >= 0.2 or n >= 512:
+            break
+        n *= 2
+    per_sim = elapsed / n
+
+    max_n = int((BUDGET - feedback_med) / per_sim) if per_sim > 0 else 1
+    max_n = max(1, max_n)
+
+    # Round down to a clean number
+    for step in (100, 50, 25, 10, 5, 1):
+        if max_n >= step:
+            rec = (max_n // step) * step
+            break
+    else:
+        rec = 1
+    if game_name in FANOUT_GAMES:
+        rec = min(rec, max_n)  # keep as computed; typically small already
+
+    # Verify the recommendation end-to-end (3 runs, report max)
+    verify = [full_validation(game_name, rec) for _ in range(3)]
+    verify_times = [v[0] for v in verify]
+
+    return {
+        "game": game_name,
+        "players": n_players,
+        "feedback_ms": round(feedback_med * 1000, 1),
+        "per_sim_ms": round(per_sim * 1000, 2),
+        "probe_batch": n,
+        "max_n_in_budget": max_n,
+        "recommended": rec,
+        "verified_total_ms": [round(t * 1000, 1) for t in sorted(verify_times)],
+        "reported_num_simulations": verify[0][1],
+    }
+
+
+def main():
+    print(f"Games: {GAMES}")
+    out = []
+    for game_name in GAMES:
+        try:
+            row = bench_game(game_name)
+        except Exception as e:  # noqa: BLE001
+            row = {"game": game_name, "error": f"{type(e).__name__}: {e}"}
+        print(json.dumps(row))
+        out.append(row)
+    print("\n=== SUMMARY ===")
+    for row in out:
+        print(json.dumps(row))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/bench_validation.py
+++ b/backend/bench_validation.py
@@ -1,8 +1,11 @@
-"""Temporary benchmark: find per-game validation simulation counts under 1s.
+"""One-off benchmark: derive each game's validation_simulations attribute.
 
 Mirrors the body of backend/tasks/validation_task.run_validation (feedback game
 + run_simulations + get_player_strategies) using each game's starter_code as
-the submitted agent. Run inside the worker image:
+the submitted agent, then recommends a per-game pass count that keeps the whole
+validation load under one second. Re-run after adding a game or changing a
+game engine, and copy the recommendation into the game class. Run inside the
+worker image:
 
 docker compose -f docker-compose.yml -f docker-compose.test.yml \
     run --rm --no-deps test-runner python backend/bench_validation.py

--- a/backend/config.py
+++ b/backend/config.py
@@ -73,20 +73,6 @@ def _discover_games(games_dir):
 GAMES = _discover_games(os.path.join(ROOT_DIR, "games"))
 
 
-# Per-game override for how many simulations a validation run executes.
-# Games that fan out into many sub-games per simulation need far fewer passes to
-# validate an agent inside the validation time limit — Hearts plays every table
-# of 4 exhaustively each pass (C(9,4)=126 games with 8 validation bots + the
-# submitted agent, i.e. 56 games per player), so a single pass is ample coverage
-# and keeps the whole validation load sub-second even on the 1 vCPU prod droplet.
-# Games not listed here fall back to the num_simulations the caller passed.
-VALIDATION_SIMULATIONS = {
-    "hearts": 1,
-    "ohhell": 1,
-    "thirteen": 1,
-}
-
-
 # Set a default SECRET_KEY for tests if not available in environment
 # In production, this should always be overridden by the actual secret key
 # from environment vars

--- a/backend/database/db_models.py
+++ b/backend/database/db_models.py
@@ -372,6 +372,21 @@ class Tutorial(SQLModel, table=True):
     )
 
 
+class LeagueTutorial(SQLModel, table=True):
+    """Attaches a tutorial to a league (many-to-many).
+
+    A league has 0..many tutorials; teams only see the tutorials attached to
+    their league. Tutorials are a global content library, so the same tutorial
+    can be attached to any number of leagues without duplicating content.
+    """
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    league_id: int = Field(foreign_key="league.id", index=True)
+    tutorial_id: int = Field(foreign_key="tutorial.id", index=True)
+
+    __table_args__ = (UniqueConstraint("league_id", "tutorial_id"),)
+
+
 class Exercise(SQLModel, table=True):
     """One coding problem inside a tutorial.
 

--- a/backend/games/arena_champions/arena_champions.py
+++ b/backend/games/arena_champions/arena_champions.py
@@ -37,6 +37,9 @@ class BattleResult:
 
 
 class ArenaChampionsGame(BaseGame):
+    # Benchmarked: ~3.6ms per simulation + feedback game keeps validation <1s.
+    validation_simulations = 200
+
     starter_code = """
 from games.arena_champions.player import Player
 import random

--- a/backend/games/base_game.py
+++ b/backend/games/base_game.py
@@ -45,6 +45,13 @@ class BaseGame(ABC):
     # Markdown shown next to the custom rewards input.
     reward_instructions = ""
 
+    # How many simulation passes a submission validation runs for this game.
+    # Each game overrides this with a value benchmarked (in the worker image)
+    # so the whole validation load — feedback game + simulations — stays under
+    # one second. Games whose run_simulations fans out into many sub-games per
+    # pass (hearts, ohhell, thirteen) need only a handful of passes.
+    validation_simulations = 20
+
     def __init__(self, league, verbose=False):
         self.verbose = verbose
         self.league = league

--- a/backend/games/breakthrough/breakthrough.py
+++ b/backend/games/breakthrough/breakthrough.py
@@ -23,6 +23,10 @@ DEFAULT_REWARDS = [100, 100, 100, 100, 50]
 
 
 class BreakthroughGame(BaseGame):
+    # Benchmarked: ~104ms per simulation (a full round-robin of board games)
+    # + ~100ms feedback game keeps validation <1s.
+    validation_simulations = 5
+
     starter_code = """
 from games.breakthrough.player import Player
 import random

--- a/backend/games/game_instructions.md
+++ b/backend/games/game_instructions.md
@@ -64,9 +64,9 @@ import string
 from backend.games.base_game import BaseGame
 
 class AlphaGuessGame(BaseGame):
-    # Simulation passes per submission validation. Benchmark the full
-    # validation load (feedback game + simulations) in the worker image and
-    # pick a value that keeps it under one second.
+    # Simulation passes per submission validation. Run
+    # backend/bench_validation.py (see its docstring) and copy the
+    # recommended value that keeps the whole validation load under one second.
     validation_simulations = 20
 
     game_instructions = """

--- a/backend/games/game_instructions.md
+++ b/backend/games/game_instructions.md
@@ -64,6 +64,11 @@ import string
 from backend.games.base_game import BaseGame
 
 class AlphaGuessGame(BaseGame):
+    # Simulation passes per submission validation. Benchmark the full
+    # validation load (feedback game + simulations) in the worker image and
+    # pick a value that keeps it under one second.
+    validation_simulations = 20
+
     game_instructions = """
     <h1>Alpha Guess Game Instructions</h1>
     <p>Try to guess the randomly chosen letter! Each correct guess scores a point.</p>

--- a/backend/games/greedy_pig/greedy_pig.py
+++ b/backend/games/greedy_pig/greedy_pig.py
@@ -11,6 +11,9 @@ class GreedyPigGame(BaseGame):
     # Safety net: a player holding this much unbanked money is forced to bank.
     FAILSAFE_BANK_AT = 150
 
+    # Benchmarked: ~0.8ms per simulation keeps validation <1s.
+    validation_simulations = 900
+
     starter_code = """
 from games.greedy_pig.player import Player
 import random

--- a/backend/games/greedy_pig/greedy_pig.py
+++ b/backend/games/greedy_pig/greedy_pig.py
@@ -12,7 +12,7 @@ class GreedyPigGame(BaseGame):
     FAILSAFE_BANK_AT = 150
 
     # Benchmarked: ~0.8ms per simulation keeps validation <1s.
-    validation_simulations = 900
+    validation_simulations = 300
 
     starter_code = """
 from games.greedy_pig.player import Player

--- a/backend/games/hearts/hearts.py
+++ b/backend/games/hearts/hearts.py
@@ -117,6 +117,10 @@ class HeartsGame(BaseGame):
     SCHEDULER_ROUNDS_PER_CALL = 5
     MAX_TOTAL_GAMES = 6000
 
+    # Benchmarked: one pass plays every table of 4 exhaustively (~374ms with
+    # the 8 validation bots + submission), so 2 passes keep validation <1s.
+    validation_simulations = 2
+
     starter_code = """
 from games.hearts.player import Player
 import random

--- a/backend/games/lineup4/lineup4.py
+++ b/backend/games/lineup4/lineup4.py
@@ -6,6 +6,10 @@ from backend.games.base_game import BaseGame
 
 
 class Lineup4Game(BaseGame):
+    # Benchmarked: ~11ms per simulation (a full round-robin of boards) keeps
+    # validation <1s; 30 also stays below run_simulations' 1000-match cap.
+    validation_simulations = 30
+
     starter_code = """
 from games.lineup4.player import Player
 import random

--- a/backend/games/ohhell/ohhell.py
+++ b/backend/games/ohhell/ohhell.py
@@ -115,6 +115,10 @@ class OhHellGame(BaseGame):
     SCHEDULER_ROUNDS_PER_CALL = 5
     MAX_TOTAL_GAMES = 6000
 
+    # Benchmarked: ~16ms per pass (each pass fans out into many sub-games)
+    # keeps validation <1s.
+    validation_simulations = 40
+
     starter_code = """
 from games.ohhell.player import Player
 import random

--- a/backend/games/prisoners_dilemma/prisoners_dilemma.py
+++ b/backend/games/prisoners_dilemma/prisoners_dilemma.py
@@ -10,6 +10,9 @@ logger = logging.getLogger(__name__)
 
 
 class PrisonersDilemmaGame(BaseGame):
+    # Benchmarked: ~2ms per simulation keeps validation <1s.
+    validation_simulations = 300
+
     starter_code = """
 from games.prisoners_dilemma.player import Player
 import random

--- a/backend/games/thirteen/thirteen.py
+++ b/backend/games/thirteen/thirteen.py
@@ -178,6 +178,10 @@ class ThirteenGame(BaseGame):
     SCHEDULER_ROUNDS_PER_CALL = 5
     MAX_TOTAL_GAMES = 6000
 
+    # Benchmarked: ~31ms per pass (each pass fans out into many sub-games)
+    # keeps validation <1s.
+    validation_simulations = 25
+
     starter_code = """
 from games.thirteen.player import Player
 import random

--- a/backend/migrations/2026-07-12_league_tutorials.sql
+++ b/backend/migrations/2026-07-12_league_tutorials.sql
@@ -1,0 +1,32 @@
+-- Leagues now have 0..many tutorials via the leaguetutorial link table, and
+-- teams only see the tutorials attached to their league.
+--
+-- Before this change every team saw every tutorial, so the first run
+-- backfills a link row for every existing (league, tutorial) pair to preserve
+-- what teams could already see. The backfill runs ONLY when the table is
+-- first created: migrations re-run on every boot, and an unconditional
+-- backfill would silently re-attach tutorials an admin had detached.
+--
+-- Idempotent: once the table exists this whole script is a no-op. On a fresh
+-- DB init_db.py creates the table from the model first, so the backfill is
+-- skipped there too (a fresh DB has no leagues or tutorials to link anyway).
+
+DO $$
+BEGIN
+    IF to_regclass('public.leaguetutorial') IS NULL THEN
+        CREATE TABLE leaguetutorial (
+            id SERIAL PRIMARY KEY,
+            league_id INTEGER NOT NULL REFERENCES league (id),
+            tutorial_id INTEGER NOT NULL REFERENCES tutorial (id),
+            CONSTRAINT leaguetutorial_league_id_tutorial_id_key
+                UNIQUE (league_id, tutorial_id)
+        );
+        CREATE INDEX ix_leaguetutorial_league_id
+            ON leaguetutorial (league_id);
+        CREATE INDEX ix_leaguetutorial_tutorial_id
+            ON leaguetutorial (tutorial_id);
+
+        INSERT INTO leaguetutorial (league_id, tutorial_id)
+        SELECT l.id, t.id FROM league l CROSS JOIN tutorial t;
+    END IF;
+END $$;

--- a/backend/routes/admin/admin_db.py
+++ b/backend/routes/admin/admin_db.py
@@ -14,6 +14,7 @@ from backend.database.db_models import (
     InstitutionSubscription,
     League,
     LeagueType,
+    LeagueTutorial,
     SimulationResult,
     SimulationResultItem,
     Submission,
@@ -254,6 +255,11 @@ def _purge_institution_data(
 
     leagues_to_delete = [lid for lid in league_ids if lid not in leagues_to_keep]
     if leagues_to_delete:
+        session.exec(
+            delete(LeagueTutorial).where(
+                LeagueTutorial.league_id.in_(leagues_to_delete)
+            )
+        )
         session.exec(delete(League).where(League.id.in_(leagues_to_delete)))
 
     return {

--- a/backend/routes/demo/demo_db.py
+++ b/backend/routes/demo/demo_db.py
@@ -13,10 +13,12 @@ from backend.database.db_models import (
     InstitutionSubscription,
     League,
     LeagueType,
+    LeagueTutorial,
     Submission,
     SubmissionMetadata,
     Team,
     TeamType,
+    Tutorial,
     get_password_hash,
 )
 from backend.database.submission_helpers import delete_submissions_for_teams
@@ -169,6 +171,13 @@ def get_or_create_demo_league(session: Session, game_name: str) -> League:
     )
 
     session.add(demo_league)
+    session.flush()
+
+    # Demo leagues showcase the platform, so they get every tutorial.
+    for tutorial_id in session.exec(select(Tutorial.id)).all():
+        session.add(
+            LeagueTutorial(league_id=demo_league.id, tutorial_id=tutorial_id)
+        )
     session.commit()
     session.refresh(demo_league)
 

--- a/backend/routes/diagnostics/diagnostics_models.py
+++ b/backend/routes/diagnostics/diagnostics_models.py
@@ -14,4 +14,3 @@ class BenchmarkSubmission(BaseModel):
     """Payload for the load-test benchmark endpoint"""
     code: str
     game_name: str = "greedy_pig"
-    num_simulations: int = 20

--- a/backend/routes/diagnostics/diagnostics_router.py
+++ b/backend/routes/diagnostics/diagnostics_router.py
@@ -63,7 +63,6 @@ async def benchmark_submit(
             code=submission.code,
             game_name=submission.game_name,
             team_name="benchmark",
-            num_simulations=submission.num_simulations,
         )
         result = await await_validation_result(async_result)
     round_trip_ms = (time.perf_counter() - t0) * 1000

--- a/backend/routes/institution/institution_db.py
+++ b/backend/routes/institution/institution_db.py
@@ -8,13 +8,15 @@ from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, delete, select
 
 from backend.database.db_models import (Institution, League, LeagueType,
-                                        SimulationResult, SimulationResultItem,
-                                        Team, TeamType)
+                                        LeagueTutorial, SimulationResult,
+                                        SimulationResultItem, Team, TeamType)
 from backend.database.submission_helpers import delete_submissions_for_teams
 from backend.games.game_factory import GameFactory
 from backend.routes.institution.institution_models import LeagueSignUp
 from backend.schools.config import (GoogleSheetsSchoolsConfig,
                                     StaticSchoolsConfig)
+from backend.routes.tutorial.tutorial_db import (set_league_tutorials,
+                                                 validate_tutorial_ids)
 from backend.schools.providers import (GoogleSheetsSchoolsProvider,
                                        SchoolsProviderError)
 from backend.utils import process_simulation_results
@@ -113,6 +115,9 @@ def create_league(
     # Validate game name
     GameFactory.get_game_class(league_data.game)
 
+    # Validate tutorial ids up front (404) so nothing is created on failure.
+    validate_tutorial_ids(session, league_data.tutorial_ids)
+
     schools_config_model = _build_schools_config(league_data)
     schools_config = (
         schools_config_model.model_dump() if schools_config_model else None
@@ -138,12 +143,18 @@ def create_league(
 
     session.add(league)
     session.flush()
+    # Attach the selected tutorials in the same transaction: an unknown
+    # tutorial id raises (404) and rolls the league creation back with it.
+    set_league_tutorials(
+        session, league.id, league_data.tutorial_ids, commit=False
+    )
     session.commit()
     return {
         "league_id": league.id,
         "name": league.name,
         "signup_token": signup_token,
         "school_league": league_data.school_league,
+        "tutorial_ids": league_data.tutorial_ids,
     }
 
 
@@ -551,7 +562,10 @@ def delete_league(session: Session, league_id: int, institution_id: int, is_admi
         session.add(team)
 
     session.commit()
-    # Delete the league
+    # Delete the league (tutorial attachments first — they FK the league)
+    session.exec(
+        delete(LeagueTutorial).where(LeagueTutorial.league_id == league.id)
+    )
     session.delete(league)
     session.commit()
 

--- a/backend/routes/institution/institution_db.py
+++ b/backend/routes/institution/institution_db.py
@@ -4,12 +4,17 @@ import secrets
 from datetime import datetime, timedelta
 from typing import Dict, Optional, Tuple, Union
 
+from sqlalchemy import case
 from sqlalchemy.exc import IntegrityError
-from sqlmodel import Session, delete, select
+from sqlmodel import Session, delete, func, select
 
-from backend.database.db_models import (Institution, League, LeagueType,
+from backend.database.db_models import (Exercise, ExerciseSubmission,
+                                        ExerciseSubmissionMetadata,
+                                        Institution, League, LeagueType,
                                         LeagueTutorial, SimulationResult,
-                                        SimulationResultItem, Team, TeamType)
+                                        SimulationResultItem, Submission,
+                                        SubmissionMetadata, Team, TeamType,
+                                        Tutorial)
 from backend.database.submission_helpers import delete_submissions_for_teams
 from backend.games.game_factory import GameFactory
 from backend.routes.institution.institution_models import LeagueSignUp
@@ -259,6 +264,174 @@ def get_all_teams(session: Session, institution_id: int) -> Dict:
             for team in teams
         ]
     }
+
+
+def get_teams_progress(session: Session, institution_id: int) -> list:
+    """Per-team agent submission stats: attempt/validated counts, hints used,
+    and the latest attempt timestamp."""
+    teams = session.exec(
+        select(Team).where(Team.institution_id == institution_id)
+    ).all()
+    team_ids = [team.id for team in teams]
+
+    attempt_stats = {}
+    validated_counts = {}
+    if team_ids:
+        attempt_stats = {
+            team_id: (attempts, hints, latest)
+            for team_id, attempts, hints, latest in session.exec(
+                select(
+                    SubmissionMetadata.team_id,
+                    func.count(SubmissionMetadata.id),
+                    func.sum(
+                        case((SubmissionMetadata.hint_included == True, 1), else_=0)  # noqa: E712
+                    ),
+                    func.max(SubmissionMetadata.timestamp),
+                )
+                .where(SubmissionMetadata.team_id.in_(team_ids))
+                .group_by(SubmissionMetadata.team_id)
+            ).all()
+        }
+        validated_counts = dict(
+            session.exec(
+                select(SubmissionMetadata.team_id, func.count(Submission.id))
+                .join(Submission, Submission.metadata_id == SubmissionMetadata.id)
+                .where(SubmissionMetadata.team_id.in_(team_ids))
+                .group_by(SubmissionMetadata.team_id)
+            ).all()
+        )
+
+    progress = []
+    for team in teams:
+        attempts, hints, latest = attempt_stats.get(team.id, (0, 0, None))
+        progress.append(
+            {
+                "id": team.id,
+                "name": team.name,
+                "school": team.school_name,
+                "league": team.league.name if team.league else None,
+                "total_attempts": attempts,
+                "validated_submissions": validated_counts.get(team.id, 0),
+                "hints_used": hints,
+                "latest_submission": latest.isoformat() if latest else None,
+            }
+        )
+    return progress
+
+
+def get_tutorials_progress(session: Session, institution_id: int) -> list:
+    """Per-exercise attempted/passed team counts for every tutorial attached
+    to one of the institution's leagues.
+
+    A tutorial's eligible teams are the teams currently in the leagues it is
+    attached to; attempted/passed counts only include those teams, so a team
+    that submitted and then moved to a league without the tutorial drops out
+    of both sides of the rate.
+    """
+    league_names = dict(
+        session.exec(
+            select(League.id, League.name).where(
+                League.institution_id == institution_id
+            )
+        ).all()
+    )
+    if not league_names:
+        return []
+
+    leagues_by_tutorial: dict = {}
+    for link in session.exec(
+        select(LeagueTutorial).where(
+            LeagueTutorial.league_id.in_(league_names)
+        )
+    ).all():
+        leagues_by_tutorial.setdefault(link.tutorial_id, set()).add(link.league_id)
+    if not leagues_by_tutorial:
+        return []
+
+    tutorials = session.exec(
+        select(Tutorial)
+        .where(Tutorial.id.in_(leagues_by_tutorial))
+        .order_by(Tutorial.id)
+    ).all()
+
+    progress = []
+    for tutorial in tutorials:
+        tutorial_league_ids = leagues_by_tutorial[tutorial.id]
+        eligible_team_ids = set(
+            session.exec(
+                select(Team.id).where(Team.league_id.in_(tutorial_league_ids))
+            ).all()
+        )
+
+        attempted_counts = {}
+        passed_counts = {}
+        if eligible_team_ids:
+            attempted_counts = dict(
+                session.exec(
+                    select(
+                        ExerciseSubmissionMetadata.exercise_id,
+                        func.count(
+                            func.distinct(ExerciseSubmissionMetadata.team_id)
+                        ),
+                    )
+                    .join(
+                        Exercise,
+                        Exercise.id == ExerciseSubmissionMetadata.exercise_id,
+                    )
+                    .where(Exercise.tutorial_id == tutorial.id)
+                    .where(
+                        ExerciseSubmissionMetadata.team_id.in_(eligible_team_ids)
+                    )
+                    .group_by(ExerciseSubmissionMetadata.exercise_id)
+                ).all()
+            )
+            passed_counts = dict(
+                session.exec(
+                    select(
+                        ExerciseSubmissionMetadata.exercise_id,
+                        func.count(
+                            func.distinct(ExerciseSubmissionMetadata.team_id)
+                        ),
+                    )
+                    .join(
+                        ExerciseSubmission,
+                        ExerciseSubmission.metadata_id
+                        == ExerciseSubmissionMetadata.id,
+                    )
+                    .join(
+                        Exercise,
+                        Exercise.id == ExerciseSubmissionMetadata.exercise_id,
+                    )
+                    .where(Exercise.tutorial_id == tutorial.id)
+                    .where(
+                        ExerciseSubmissionMetadata.team_id.in_(eligible_team_ids)
+                    )
+                    .where(ExerciseSubmission.passed == True)  # noqa: E712
+                    .group_by(ExerciseSubmissionMetadata.exercise_id)
+                ).all()
+            )
+
+        progress.append(
+            {
+                "id": tutorial.id,
+                "title": tutorial.title,
+                "team_count": len(eligible_team_ids),
+                "league_names": sorted(
+                    league_names[league_id] for league_id in tutorial_league_ids
+                ),
+                "exercises": [
+                    {
+                        "id": exercise.id,
+                        "title": exercise.title,
+                        "order_index": exercise.order_index,
+                        "attempted_count": attempted_counts.get(exercise.id, 0),
+                        "passed_count": passed_counts.get(exercise.id, 0),
+                    }
+                    for exercise in tutorial.exercises
+                ],
+            }
+        )
+    return progress
 
 
 def get_league_by_id(session: Session, league_id: int, institution_id: int, is_admin: bool = False) -> League:

--- a/backend/routes/institution/institution_models.py
+++ b/backend/routes/institution/institution_models.py
@@ -16,6 +16,12 @@ class LeagueSignUp(BaseModel):
     school_league: bool = False
     schools: List[str] = []
     sheet_url: Optional[str] = None
+    # Tutorials to attach at creation; empty means the league has none.
+    tutorial_ids: List[int] = []
+
+    @field_validator("tutorial_ids")
+    def dedupe_tutorial_ids(cls, v):
+        return list(dict.fromkeys(v))
 
     @field_validator("name")
     def validate_name(cls, v):
@@ -166,3 +172,14 @@ class LeagueInfoUpdate(BaseModel):
 
     league_id: int
     info_markdown: str = ""
+
+
+class LeagueTutorialsUpdate(BaseModel):
+    """Model for replacing the set of tutorials attached to a league."""
+
+    league_id: int
+    tutorial_ids: List[int] = []
+
+    @field_validator("tutorial_ids")
+    def dedupe_tutorial_ids(cls, v):
+        return list(dict.fromkeys(v))

--- a/backend/routes/institution/institution_router.py
+++ b/backend/routes/institution/institution_router.py
@@ -35,11 +35,16 @@ from backend.routes.institution.institution_models import (
     LeagueInfoUpdate,
     LeagueResults,
     LeagueSignUp,
+    LeagueTutorialsUpdate,
     SimulationConfig,
     TeamDelete,
     TeamIdRef,
     TeamLeagueAssignment,
     TeamSignup,
+)
+from backend.routes.tutorial.tutorial_db import (
+    get_league_tutorial_ids,
+    set_league_tutorials,
 )
 from backend.tasks.celery_utils import poll_task_result
 from backend.tasks.simulation_task import run_simulation
@@ -307,6 +312,40 @@ async def update_league_info_endpoint(
             institution_id,
             is_admin=is_admin,
         )
+    }
+
+
+@institution_router.post("/get-league-tutorials")
+@verify_admin_or_institution
+async def get_league_tutorials_endpoint(
+    payload: LeagueIdRef,
+    current_user: dict = Depends(get_current_user),
+    session: Session = Depends(get_db),
+):
+    """Ids of the tutorials attached to one of the caller's leagues."""
+    institution_id, is_admin = _require_institution(current_user)
+    league = get_league_by_id(
+        session, payload.league_id, institution_id, is_admin=is_admin
+    )
+    return {"tutorial_ids": get_league_tutorial_ids(session, league.id)}
+
+
+@institution_router.post("/update-league-tutorials")
+@verify_admin_or_institution
+async def update_league_tutorials_endpoint(
+    payload: LeagueTutorialsUpdate,
+    current_user: dict = Depends(get_current_user),
+    session: Session = Depends(get_db),
+):
+    """Replace the set of tutorials attached to one of the caller's leagues."""
+    institution_id, is_admin = _require_institution(current_user)
+    league = get_league_by_id(
+        session, payload.league_id, institution_id, is_admin=is_admin
+    )
+    tutorial_ids = set_league_tutorials(session, league.id, payload.tutorial_ids)
+    return {
+        "message": f"Tutorials updated for league '{league.name}'",
+        "tutorial_ids": tutorial_ids,
     }
 
 

--- a/backend/routes/institution/institution_router.py
+++ b/backend/routes/institution/institution_router.py
@@ -22,6 +22,8 @@ from backend.routes.institution.institution_db import (
     get_all_league_results,
     get_all_teams,
     get_league_by_id,
+    get_teams_progress,
+    get_tutorials_progress,
     publish_sim_results,
     save_simulation_results,
     unassign_team,
@@ -135,6 +137,22 @@ async def get_teams_endpoint(
     """Get all teams for the institution."""
     institution_id, _ = _require_institution(current_user)
     return get_all_teams(session, institution_id)
+
+
+@institution_router.get("/team-progress")
+@verify_admin_or_institution
+async def team_progress_endpoint(
+    session: Session = Depends(get_db),
+    current_user: dict = Depends(get_current_user),
+):
+    """Data backing the Team Progress tab: per-team agent submission stats
+    plus per-exercise completion counts for each tutorial attached to the
+    institution's leagues."""
+    institution_id, _ = _require_institution(current_user)
+    return {
+        "teams": get_teams_progress(session, institution_id),
+        "tutorials": get_tutorials_progress(session, institution_id),
+    }
 
 
 @institution_router.get("/subscription")

--- a/backend/routes/tutorial/tutorial_db.py
+++ b/backend/routes/tutorial/tutorial_db.py
@@ -8,6 +8,8 @@ from backend.database.db_models import (
     Exercise,
     ExerciseSubmission,
     ExerciseSubmissionMetadata,
+    LeagueTutorial,
+    Team,
     Tutorial,
 )
 # Reused so the existing 429 handler in api.py covers exercise rate limiting.
@@ -70,9 +72,59 @@ def get_exercise_by_id(session: Session, exercise_id: int) -> Exercise:
     return exercise
 
 
-def get_tutorials(session: Session) -> dict:
-    """List all tutorials with their exercise counts."""
-    tutorials = session.exec(select(Tutorial).order_by(Tutorial.id)).all()
+def get_team_league_id(session: Session, team_id: int) -> Optional[int]:
+    """The league a team currently belongs to, resolved from the DB (not the
+    token) so a mid-session league move takes effect immediately."""
+    team = session.get(Team, team_id)
+    return team.league_id if team else None
+
+
+def is_tutorial_in_league(
+    session: Session, tutorial_id: int, league_id: Optional[int]
+) -> bool:
+    if league_id is None:
+        return False
+    return (
+        session.exec(
+            select(LeagueTutorial)
+            .where(LeagueTutorial.tutorial_id == tutorial_id)
+            .where(LeagueTutorial.league_id == league_id)
+        ).first()
+        is not None
+    )
+
+
+def assert_tutorial_in_team_league(
+    session: Session, tutorial_id: int, team_id: int
+) -> None:
+    """404 when the tutorial isn't attached to the team's league — the same
+    response as a nonexistent id, so students can't probe other leagues'
+    content."""
+    league_id = get_team_league_id(session, team_id)
+    if not is_tutorial_in_league(session, tutorial_id, league_id):
+        raise TutorialNotFoundError(f"Tutorial with ID {tutorial_id} not found")
+
+
+def assert_exercise_in_team_league(
+    session: Session, exercise: Exercise, team_id: int
+) -> None:
+    """Exercise-flavoured twin of assert_tutorial_in_team_league."""
+    league_id = get_team_league_id(session, team_id)
+    if not is_tutorial_in_league(session, exercise.tutorial_id, league_id):
+        raise ExerciseNotFoundError(f"Exercise with ID {exercise.id} not found")
+
+
+def get_tutorials(session: Session, league_id: Optional[int] = None) -> dict:
+    """List tutorials with their exercise counts.
+
+    With a league_id, only tutorials attached to that league (the team view);
+    without one, the full library (admin/institution view)."""
+    query = select(Tutorial).order_by(Tutorial.id)
+    if league_id is not None:
+        query = query.join(
+            LeagueTutorial, LeagueTutorial.tutorial_id == Tutorial.id
+        ).where(LeagueTutorial.league_id == league_id)
+    tutorials = session.exec(query).all()
     counts = dict(
         session.exec(
             select(Exercise.tutorial_id, func.count(Exercise.id)).group_by(
@@ -353,14 +405,75 @@ def update_tutorial(
 
 
 def delete_tutorial(session: Session, tutorial_id: int) -> None:
-    """Delete a tutorial, its exercises, and all their submission history."""
+    """Delete a tutorial, its exercises, all their submission history, and
+    its league attachments."""
     tutorial = _get_tutorial_or_raise(session, tutorial_id)
     _delete_submission_history(
         session, [exercise.id for exercise in tutorial.exercises]
     )
+    for link in session.exec(
+        select(LeagueTutorial).where(LeagueTutorial.tutorial_id == tutorial_id)
+    ).all():
+        session.delete(link)
     # The exercises relationship cascades with delete-orphan.
     session.delete(tutorial)
     session.commit()
+
+
+def get_league_tutorial_ids(session: Session, league_id: int) -> list:
+    """Ids of the tutorials attached to a league, in tutorial-id order."""
+    return list(
+        session.exec(
+            select(LeagueTutorial.tutorial_id)
+            .where(LeagueTutorial.league_id == league_id)
+            .order_by(LeagueTutorial.tutorial_id)
+        ).all()
+    )
+
+
+def validate_tutorial_ids(session: Session, tutorial_ids: list) -> None:
+    """Raise TutorialNotFoundError (404) unless every id exists."""
+    wanted = set(tutorial_ids)
+    if not wanted:
+        return
+    found = set(
+        session.exec(select(Tutorial.id).where(Tutorial.id.in_(wanted))).all()
+    )
+    missing = wanted - found
+    if missing:
+        raise TutorialNotFoundError(
+            f"Tutorial with ID {sorted(missing)[0]} not found"
+        )
+
+
+def set_league_tutorials(
+    session: Session, league_id: int, tutorial_ids: list, commit: bool = True
+) -> list:
+    """Replace a league's attached tutorials with exactly `tutorial_ids`.
+
+    Replace-all semantics (like reorder_exercises) so the caller never has to
+    reason about attach/detach deltas. Unknown tutorial ids 404 before
+    anything is changed. Returns the new id list.
+    """
+    validate_tutorial_ids(session, tutorial_ids)
+    wanted = set(tutorial_ids)
+
+    existing = {
+        link.tutorial_id: link
+        for link in session.exec(
+            select(LeagueTutorial).where(LeagueTutorial.league_id == league_id)
+        ).all()
+    }
+    for tutorial_id, link in existing.items():
+        if tutorial_id not in wanted:
+            session.delete(link)
+    for tutorial_id in wanted - set(existing):
+        session.add(
+            LeagueTutorial(league_id=league_id, tutorial_id=tutorial_id)
+        )
+    if commit:
+        session.commit()
+    return sorted(wanted)
 
 
 def create_exercise(

--- a/backend/routes/tutorial/tutorial_router.py
+++ b/backend/routes/tutorial/tutorial_router.py
@@ -13,6 +13,8 @@ from backend.routes.auth.auth_core import (
 )
 from backend.routes.tutorial.tutorial_db import (
     allow_exercise_submission,
+    assert_exercise_in_team_league,
+    assert_tutorial_in_team_league,
     create_exercise,
     create_tutorial,
     delete_exercise,
@@ -20,6 +22,7 @@ from backend.routes.tutorial.tutorial_db import (
     get_exercise_by_id,
     get_exercise_submission_history,
     get_latest_exercise_submission,
+    get_team_league_id,
     get_tutorial_admin_detail,
     get_tutorial_progress,
     get_tutorial_with_exercises,
@@ -79,6 +82,7 @@ async def submit_exercise(
     """
     team_id = _require_team_id(current_user)
     exercise = get_exercise_by_id(session, submission.exercise_id)
+    assert_exercise_in_team_league(session, exercise, team_id)
     allow_exercise_submission(session, team_id)
 
     # AST safety check runs here, before enqueue: cheap, and unsafe code
@@ -137,14 +141,33 @@ async def submit_exercise(
     }
 
 
+def _is_content_manager(current_user: dict) -> bool:
+    """Admins and institutions browse the full tutorial library (they attach
+    tutorials to leagues); every other role sees only its league's tutorials."""
+    return current_user.get("role") in ("admin", "institution")
+
+
 @tutorial_router.get("/tutorials")
 @verify_any_role
 async def get_tutorials_endpoint(
     current_user: dict = Depends(get_current_user),
     session: Session = Depends(get_db),
 ):
-    """List all tutorials with their exercise counts."""
-    return get_tutorials(session)
+    """List tutorials with their exercise counts.
+
+    Admin/institution tokens see the full library; team tokens see only the
+    tutorials attached to their league.
+    """
+    if _is_content_manager(current_user):
+        return get_tutorials(session)
+
+    team_id = current_user.get("team_id")
+    league_id = (
+        get_team_league_id(session, team_id) if team_id is not None else None
+    )
+    if league_id is None:
+        return {"tutorials": []}
+    return get_tutorials(session, league_id=league_id)
 
 
 @tutorial_router.get("/tutorial/{tutorial_id}")
@@ -154,7 +177,14 @@ async def get_tutorial_endpoint(
     current_user: dict = Depends(get_current_user),
     session: Session = Depends(get_db),
 ):
-    """Get one tutorial with its exercises in order."""
+    """Get one tutorial with its exercises in order.
+
+    Team tokens can only open tutorials attached to their league; anything
+    else 404s exactly like a nonexistent id.
+    """
+    if not _is_content_manager(current_user):
+        team_id = _require_team_id(current_user)
+        assert_tutorial_in_team_league(session, tutorial_id, team_id)
     return get_tutorial_with_exercises(session, tutorial_id)
 
 
@@ -167,6 +197,7 @@ async def get_tutorial_progress_endpoint(
 ):
     """Current team's attempted/passed status for each exercise, in order."""
     team_id = _require_team_id(current_user)
+    assert_tutorial_in_team_league(session, tutorial_id, team_id)
     return get_tutorial_progress(session, team_id, tutorial_id)
 
 
@@ -298,7 +329,8 @@ async def get_latest_exercise_submission_endpoint(
 ):
     """Latest stored submission by the current team for one exercise."""
     team_id = _require_team_id(current_user)
-    get_exercise_by_id(session, exercise_id)
+    exercise = get_exercise_by_id(session, exercise_id)
+    assert_exercise_in_team_league(session, exercise, team_id)
     return get_latest_exercise_submission(session, team_id, exercise_id)
 
 
@@ -311,7 +343,8 @@ async def get_exercise_submissions_endpoint(
 ):
     """Full submission history by the current team for one exercise."""
     team_id = _require_team_id(current_user)
-    get_exercise_by_id(session, exercise_id)
+    exercise = get_exercise_by_id(session, exercise_id)
+    assert_exercise_in_team_league(session, exercise, team_id)
     return {
         "submissions": get_exercise_submission_history(
             session, team_id, exercise_id

--- a/backend/routes/user/user_router.py
+++ b/backend/routes/user/user_router.py
@@ -156,7 +156,6 @@ async def submit_agent(
             code=submission.code,
             game_name=team.league.game,
             team_name=team_name,
-            num_simulations=20,
         )
         # Polls the backend (no thread, no shared pubsub consumer) and maps
         # every kill/timeout/worker-loss to a clean validation failure.

--- a/backend/scripts/seed_tutorial.py
+++ b/backend/scripts/seed_tutorial.py
@@ -31,6 +31,8 @@ sys.path.append(
 from backend.database.db_models import (
     Exercise,
     ExerciseSubmissionMetadata,
+    League,
+    LeagueTutorial,
     Tutorial,
 )
 from backend.database.db_session import get_db_engine
@@ -909,6 +911,12 @@ def seed_tutorial() -> bool:
             logger.info(f"Deleting extra tutorial '{extra.title}'")
             for exercise in list(extra.exercises):
                 _delete_exercise(session, exercise)
+            for link in session.exec(
+                select(LeagueTutorial).where(
+                    LeagueTutorial.tutorial_id == extra.id
+                )
+            ).all():
+                session.delete(link)
             session.delete(extra)
 
         if tutorial:
@@ -953,6 +961,22 @@ def seed_tutorial() -> bool:
         for leftover in existing[len(EXERCISES):]:
             logger.info(f"Deleting leftover exercise '{leftover.title}'")
             _delete_exercise(session, leftover)
+
+        # Attach the tutorial to every league that doesn't already have it,
+        # so a seeded dev/demo environment shows the tutorial everywhere.
+        # (Teams only see tutorials attached to their league.)
+        linked_league_ids = set(
+            session.exec(
+                select(LeagueTutorial.league_id).where(
+                    LeagueTutorial.tutorial_id == tutorial.id
+                )
+            ).all()
+        )
+        for league_id in session.exec(select(League.id)).all():
+            if league_id not in linked_league_ids:
+                session.add(
+                    LeagueTutorial(league_id=league_id, tutorial_id=tutorial.id)
+                )
 
         session.commit()
         logger.info(

--- a/backend/server_stress_test/README.md
+++ b/backend/server_stress_test/README.md
@@ -124,7 +124,6 @@ the finding. Run `monitor_cpu.sh` alongside the illegal test.
 | Var | Default | Meaning |
 |-----|---------|---------|
 | `WAIT_MIN` / `WAIT_MAX` | `0` / `0` | per-user pause (s) between submissions; 0 = max throughput |
-| `NUM_SIMULATIONS` | `20` | sims per submission (20 = prod parity) |
 | `W_VALID` | `80` | weight of valid agents in the mix |
 | `W_SPIN` | `3` | weight of infinite-loop (timeout) agents; `0` = pure valid run |
 | `W_SLOW` | `7` | weight of heavy-but-legal agents (finish under the 5s cap) |

--- a/backend/server_stress_test/bench_common.py
+++ b/backend/server_stress_test/bench_common.py
@@ -11,9 +11,6 @@ import random
 
 BENCHMARK_TOKEN = os.environ.get("BENCHMARK_TOKEN", "")
 
-# Simulations per submission. 20 matches what /user/submit-agent sends in prod.
-NUM_SIMULATIONS = int(os.environ.get("NUM_SIMULATIONS", "20"))
-
 
 # --- Agent code generators --------------------------------------------------
 # Each returns a distinct payload per call (random tweak) so no layer can cache
@@ -155,7 +152,6 @@ def submit(user, code: str, name: str, expect_success: bool):
     payload = {
         "code": code,
         "game_name": "greedy_pig",
-        "num_simulations": NUM_SIMULATIONS,
     }
     with user.client.post(
         "/diagnostics/benchmark-submit",

--- a/backend/server_stress_test/locust_legal_only.py
+++ b/backend/server_stress_test/locust_legal_only.py
@@ -19,8 +19,7 @@ Run with -u equal to USERS (default 30):
         --host https://your-prod-host \
         --csv bench_legal
 
-Env knobs: TARGET_RPS (default 10), USERS (default 30, keep -u equal),
-NUM_SIMULATIONS (default 20).
+Env knobs: TARGET_RPS (default 10), USERS (default 30, keep -u equal).
 """
 
 import logging

--- a/backend/tasks/validation_task.py
+++ b/backend/tasks/validation_task.py
@@ -21,7 +21,6 @@ from typing import Any, Dict, Optional
 from billiard.exceptions import WorkerLostError
 from celery.exceptions import SoftTimeLimitExceeded, TimeLimitExceeded
 
-from backend.config import VALIDATION_SIMULATIONS
 from backend.database.db_models import League
 from backend.games.base_game import PlayerConstructionError
 from backend.games.game_factory import GameFactory
@@ -98,7 +97,6 @@ def enqueue_validation(
     code: str,
     game_name: str,
     team_name: str,
-    num_simulations: int = 20,
     custom_rewards: Optional[list] = None,
 ):
     """Enqueue a validation task that self-drops if it waits out its usefulness.
@@ -112,7 +110,6 @@ def enqueue_validation(
             "code": code,
             "game_name": game_name,
             "team_name": team_name,
-            "num_simulations": num_simulations,
             "custom_rewards": custom_rewards,
         },
         expires=VALIDATION_TASK_EXPIRES,
@@ -149,7 +146,6 @@ def run_validation(
     code: str,
     game_name: str,
     team_name: str,
-    num_simulations: int = 100,
     custom_rewards: Optional[list] = None,
 ) -> Dict[str, Any]:
     """Run the full validation load and return the ValidationResponse dict."""
@@ -171,11 +167,10 @@ def run_validation(
                 custom_rewards
             )
             game_instance.reset()
-            # Per-game override: games that fan out into many sub-games per
-            # simulation (e.g. Hearts) validate in far fewer passes.
-            sim_count = VALIDATION_SIMULATIONS.get(game_name, num_simulations)
+            # Each game declares its own validation pass count, benchmarked
+            # so the whole load stays under one second.
             simulation_results = game_instance.run_simulations(
-                sim_count, test_league, custom_rewards
+                game_class.validation_simulations, test_league, custom_rewards
             )
             simulation_results["strategies"] = (
                 game_instance.get_player_strategies()

--- a/backend/tests/games/test_agent_error_traces.py
+++ b/backend/tests/games/test_agent_error_traces.py
@@ -52,9 +52,7 @@ class CustomPlayer(Player):
 
 
 def _validate(code: str, game: str) -> dict:
-    return run_validation(
-        code=code, game_name=game, team_name="CrashTeam", num_simulations=2
-    )
+    return run_validation(code=code, game_name=game, team_name="CrashTeam")
 
 
 # --- Crashing agents abort every game: chained traceback at the task boundary

--- a/backend/tests/integration/routes/institution/test_league_tutorials.py
+++ b/backend/tests/integration/routes/institution/test_league_tutorials.py
@@ -1,0 +1,251 @@
+"""League-tutorial attachments: selection at league creation, the
+get/update-league-tutorials endpoints, ownership, and FK cleanup on delete."""
+
+import pytest
+from sqlmodel import Session, select
+
+from backend.database.db_models import League, LeagueTutorial, Tutorial
+
+
+@pytest.fixture
+def tutorials(db_session: Session) -> list:
+    """Two tutorials in the global library."""
+    created = []
+    for title in ["Python Basics", "Greedy Pig Prep"]:
+        tutorial = Tutorial(title=title, description=f"{title} description")
+        db_session.add(tutorial)
+        created.append(tutorial)
+    db_session.commit()
+    for tutorial in created:
+        db_session.refresh(tutorial)
+    return created
+
+
+def get_league_links(db_session: Session, league_id: int) -> list:
+    return list(
+        db_session.exec(
+            select(LeagueTutorial.tutorial_id)
+            .where(LeagueTutorial.league_id == league_id)
+            .order_by(LeagueTutorial.tutorial_id)
+        ).all()
+    )
+
+
+def test_league_create_with_tutorials(
+    client, institution_headers, db_session, tutorials
+):
+    tutorial_ids = [t.id for t in tutorials]
+    response = client.post(
+        "/institution/league-create",
+        headers=institution_headers,
+        json={
+            "name": "league_with_tutorials",
+            "game": "greedy_pig",
+            "tutorial_ids": tutorial_ids,
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert sorted(data["tutorial_ids"]) == sorted(tutorial_ids)
+    assert get_league_links(db_session, data["league_id"]) == sorted(tutorial_ids)
+
+    # The endpoint reads them back
+    response = client.post(
+        "/institution/get-league-tutorials",
+        headers=institution_headers,
+        json={"league_id": data["league_id"]},
+    )
+    assert response.status_code == 200
+    assert response.json()["tutorial_ids"] == sorted(tutorial_ids)
+
+
+def test_league_create_without_tutorials(
+    client, institution_headers, db_session
+):
+    """tutorial_ids is optional; omitting it creates a league with none."""
+    response = client.post(
+        "/institution/league-create",
+        headers=institution_headers,
+        json={"name": "league_no_tutorials", "game": "greedy_pig"},
+    )
+    assert response.status_code == 200
+    assert response.json()["tutorial_ids"] == []
+    assert get_league_links(db_session, response.json()["league_id"]) == []
+
+
+def test_league_create_unknown_tutorial_rolls_back(
+    client, institution_headers, db_session
+):
+    response = client.post(
+        "/institution/league-create",
+        headers=institution_headers,
+        json={
+            "name": "league_bad_tutorial",
+            "game": "greedy_pig",
+            "tutorial_ids": [99999],
+        },
+    )
+    assert response.status_code == 404
+    assert (
+        db_session.exec(
+            select(League).where(League.name == "league_bad_tutorial")
+        ).first()
+        is None
+    )
+
+
+def test_update_league_tutorials_replaces_set(
+    client, institution_headers, db_session, tutorials
+):
+    response = client.post(
+        "/institution/league-create",
+        headers=institution_headers,
+        json={
+            "name": "league_to_edit",
+            "game": "greedy_pig",
+            "tutorial_ids": [tutorials[0].id],
+        },
+    )
+    league_id = response.json()["league_id"]
+
+    response = client.post(
+        "/institution/update-league-tutorials",
+        headers=institution_headers,
+        json={"league_id": league_id, "tutorial_ids": [tutorials[1].id]},
+    )
+    assert response.status_code == 200
+    assert response.json()["tutorial_ids"] == [tutorials[1].id]
+    assert get_league_links(db_session, league_id) == [tutorials[1].id]
+
+    # Detach everything
+    response = client.post(
+        "/institution/update-league-tutorials",
+        headers=institution_headers,
+        json={"league_id": league_id, "tutorial_ids": []},
+    )
+    assert response.status_code == 200
+    assert get_league_links(db_session, league_id) == []
+
+
+def test_update_league_tutorials_unknown_tutorial(
+    client, institution_headers, db_session, tutorials
+):
+    response = client.post(
+        "/institution/league-create",
+        headers=institution_headers,
+        json={
+            "name": "league_bad_update",
+            "game": "greedy_pig",
+            "tutorial_ids": [tutorials[0].id],
+        },
+    )
+    league_id = response.json()["league_id"]
+
+    response = client.post(
+        "/institution/update-league-tutorials",
+        headers=institution_headers,
+        json={"league_id": league_id, "tutorial_ids": [99999]},
+    )
+    assert response.status_code == 404
+    # Attachments unchanged
+    assert get_league_links(db_session, league_id) == [tutorials[0].id]
+
+
+def test_league_tutorials_ownership(
+    client, institution_headers, auth_headers, db_session, tutorials
+):
+    """An institution can't read or edit another institution's league; an
+    admin can edit any league."""
+    other_league = db_session.exec(
+        select(League).where(League.name == "greedy_pig_league")
+    ).one()  # owned by the seeded Admin Institution
+
+    response = client.post(
+        "/institution/get-league-tutorials",
+        headers=institution_headers,
+        json={"league_id": other_league.id},
+    )
+    assert response.status_code == 403
+
+    response = client.post(
+        "/institution/update-league-tutorials",
+        headers=institution_headers,
+        json={"league_id": other_league.id, "tutorial_ids": [tutorials[0].id]},
+    )
+    assert response.status_code == 403
+    assert get_league_links(db_session, other_league.id) == []
+
+    response = client.post(
+        "/institution/update-league-tutorials",
+        headers=auth_headers,
+        json={"league_id": other_league.id, "tutorial_ids": [tutorials[0].id]},
+    )
+    assert response.status_code == 200
+    assert get_league_links(db_session, other_league.id) == [tutorials[0].id]
+
+    # Unknown league 404s
+    response = client.post(
+        "/institution/get-league-tutorials",
+        headers=auth_headers,
+        json={"league_id": 99999},
+    )
+    assert response.status_code == 404
+
+
+def test_league_tutorials_role_gating(client, team_headers, tutorials):
+    response = client.post(
+        "/institution/get-league-tutorials",
+        headers=team_headers,
+        json={"league_id": 1},
+    )
+    assert response.status_code == 403
+
+    response = client.post(
+        "/institution/update-league-tutorials",
+        headers=team_headers,
+        json={"league_id": 1, "tutorial_ids": []},
+    )
+    assert response.status_code == 403
+
+
+def test_delete_league_removes_attachments(
+    client, institution_headers, db_session, tutorials
+):
+    response = client.post(
+        "/institution/league-create",
+        headers=institution_headers,
+        json={
+            "name": "league_to_delete",
+            "game": "greedy_pig",
+            "tutorial_ids": [t.id for t in tutorials],
+        },
+    )
+    league_id = response.json()["league_id"]
+
+    response = client.post(
+        "/institution/delete-league",
+        headers=institution_headers,
+        json={"league_id": league_id},
+    )
+    assert response.status_code == 200
+    assert get_league_links(db_session, league_id) == []
+    # The tutorials themselves survive
+    assert len(db_session.exec(select(Tutorial)).all()) == 2
+
+
+def test_delete_tutorial_removes_attachments(
+    client, auth_headers, db_session, tutorials
+):
+    league = db_session.exec(
+        select(League).where(League.name == "greedy_pig_league")
+    ).one()
+    db_session.add(
+        LeagueTutorial(league_id=league.id, tutorial_id=tutorials[0].id)
+    )
+    db_session.commit()
+
+    response = client.delete(
+        f"/tutorial/tutorial/{tutorials[0].id}", headers=auth_headers
+    )
+    assert response.status_code == 200
+    assert get_league_links(db_session, league.id) == []

--- a/backend/tests/integration/routes/institution/test_team_progress.py
+++ b/backend/tests/integration/routes/institution/test_team_progress.py
@@ -1,0 +1,259 @@
+"""The /institution/team-progress endpoint: per-team agent submission stats
+plus per-tutorial exercise completion counts, scoped to the caller's
+institution."""
+
+from datetime import timedelta
+from types import SimpleNamespace
+
+import pytest
+from sqlmodel import Session
+
+from backend.database.db_models import (
+    Exercise,
+    ExerciseSubmission,
+    ExerciseSubmissionMetadata,
+    League,
+    LeagueTutorial,
+    Team,
+    Tutorial,
+)
+from backend.routes.auth.auth_core import create_access_token
+from backend.tests.conftest import (
+    add_failed_submission,
+    add_submission,
+    create_test_institution,
+)
+from backend.time_utils import utc_now
+
+
+def add_exercise_attempt(
+    db_session: Session, team_id: int, exercise_id: int, passed=None
+):
+    """One attempt: metadata-only when passed is None, otherwise a stored run."""
+    now = utc_now()
+    meta = ExerciseSubmissionMetadata(
+        team_id=team_id, exercise_id=exercise_id, timestamp=now
+    )
+    db_session.add(meta)
+    if passed is not None:
+        db_session.flush()
+        db_session.add(
+            ExerciseSubmission(
+                code="def solve(): pass",
+                timestamp=now,
+                passed=passed,
+                test_results=[],
+                metadata_id=meta.id,
+            )
+        )
+
+
+@pytest.fixture
+def progress_setup(db_session: Session) -> SimpleNamespace:
+    """An institution with two leagues, a tutorial attached to one of them,
+    and three teams with a mix of agent and exercise submissions."""
+    institution = create_test_institution(
+        db_session, name="progress_institution", password_hash="test_hash"
+    )
+
+    league_a = League(
+        name="progress_league_a",
+        created_date=utc_now(),
+        expiry_date=utc_now() + timedelta(days=7),
+        game="greedy_pig",
+        institution_id=institution.id,
+    )
+    league_b = League(
+        name="progress_league_b",
+        created_date=utc_now(),
+        expiry_date=utc_now() + timedelta(days=7),
+        game="greedy_pig",
+        institution_id=institution.id,
+    )
+    db_session.add(league_a)
+    db_session.add(league_b)
+    db_session.commit()
+
+    tutorial = Tutorial(title="Progress Tutorial", description="desc")
+    db_session.add(tutorial)
+    db_session.commit()
+    exercise_one = Exercise(
+        tutorial_id=tutorial.id,
+        order_index=0,
+        title="Exercise One",
+        problem_markdown="p",
+        entry_function="solve",
+        test_cases=[],
+    )
+    exercise_two = Exercise(
+        tutorial_id=tutorial.id,
+        order_index=1,
+        title="Exercise Two",
+        problem_markdown="p",
+        entry_function="solve",
+        test_cases=[],
+    )
+    db_session.add(exercise_one)
+    db_session.add(exercise_two)
+    db_session.add(
+        LeagueTutorial(league_id=league_a.id, tutorial_id=tutorial.id)
+    )
+    db_session.commit()
+
+    alpha = Team(
+        name="progress_alpha",
+        school_name="School A",
+        password_hash="test_hash",
+        league_id=league_a.id,
+        institution_id=institution.id,
+    )
+    beta = Team(
+        name="progress_beta",
+        school_name="School B",
+        password_hash="test_hash",
+        league_id=league_a.id,
+        institution_id=institution.id,
+    )
+    gamma = Team(
+        name="progress_gamma",
+        school_name="School C",
+        password_hash="test_hash",
+        league_id=league_b.id,
+        institution_id=institution.id,
+    )
+    for team in (alpha, beta, gamma):
+        db_session.add(team)
+    db_session.commit()
+    for team in (alpha, beta, gamma):
+        db_session.refresh(team)
+
+    # Agent submissions for alpha: two validated (one with a hint), one failed
+    now = utc_now()
+    add_submission(
+        db_session,
+        code="agent v1",
+        timestamp=now - timedelta(minutes=5),
+        team_id=alpha.id,
+        league_id=league_a.id,
+    )
+    add_submission(
+        db_session,
+        code="agent v2",
+        timestamp=now,
+        team_id=alpha.id,
+        league_id=league_a.id,
+        hint_included=True,
+    )
+    add_failed_submission(
+        db_session,
+        timestamp=now - timedelta(minutes=2),
+        team_id=alpha.id,
+        league_id=league_a.id,
+    )
+
+    # Exercise one: alpha fails then passes; beta's attempt never ran; gamma
+    # passes but is in a league without the tutorial, so it must not count.
+    add_exercise_attempt(db_session, alpha.id, exercise_one.id, passed=False)
+    add_exercise_attempt(db_session, alpha.id, exercise_one.id, passed=True)
+    add_exercise_attempt(db_session, beta.id, exercise_one.id)
+    add_exercise_attempt(db_session, gamma.id, exercise_one.id, passed=True)
+    db_session.commit()
+
+    token = create_access_token(
+        data={
+            "sub": institution.name,
+            "role": "institution",
+            "institution_id": institution.id,
+        },
+        expires_delta=timedelta(minutes=30),
+    )
+    return SimpleNamespace(
+        institution=institution,
+        tutorial=tutorial,
+        exercises=(exercise_one, exercise_two),
+        teams=(alpha, beta, gamma),
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+
+def test_team_progress_success(client, progress_setup):
+    response = client.get(
+        "/institution/team-progress", headers=progress_setup.headers
+    )
+    assert response.status_code == 200
+    data = response.json()
+
+    # Only this institution's teams appear (the seed data has others)
+    teams = {team["name"]: team for team in data["teams"]}
+    assert set(teams) == {"progress_alpha", "progress_beta", "progress_gamma"}
+
+    alpha = teams["progress_alpha"]
+    assert alpha["league"] == "progress_league_a"
+    assert alpha["school"] == "School A"
+    assert alpha["total_attempts"] == 3
+    assert alpha["validated_submissions"] == 2
+    assert alpha["hints_used"] == 1
+    assert alpha["latest_submission"] is not None
+
+    for name in ("progress_beta", "progress_gamma"):
+        assert teams[name]["total_attempts"] == 0
+        assert teams[name]["validated_submissions"] == 0
+        assert teams[name]["hints_used"] == 0
+        assert teams[name]["latest_submission"] is None
+
+    # One tutorial, scoped to league_a's two teams
+    assert len(data["tutorials"]) == 1
+    tutorial = data["tutorials"][0]
+    assert tutorial["id"] == progress_setup.tutorial.id
+    assert tutorial["title"] == "Progress Tutorial"
+    assert tutorial["team_count"] == 2
+    assert tutorial["league_names"] == ["progress_league_a"]
+
+    exercise_one, exercise_two = progress_setup.exercises
+    exercises = tutorial["exercises"]
+    assert [e["id"] for e in exercises] == [exercise_one.id, exercise_two.id]
+    # alpha ran, beta's attempt is metadata-only, gamma is out of scope
+    assert exercises[0]["attempted_count"] == 2
+    assert exercises[0]["passed_count"] == 1
+    assert exercises[1]["attempted_count"] == 0
+    assert exercises[1]["passed_count"] == 0
+
+
+def test_team_progress_empty_institution(client, institution_headers):
+    """A fresh institution with no leagues or teams gets empty sections."""
+    response = client.get(
+        "/institution/team-progress", headers=institution_headers
+    )
+    assert response.status_code == 200
+    assert response.json() == {"teams": [], "tutorials": []}
+
+
+def test_team_progress_admin_sees_own_institution(
+    client, auth_headers, progress_setup
+):
+    """Admin tokens resolve to institution 1, not to other institutions."""
+    response = client.get("/institution/team-progress", headers=auth_headers)
+    assert response.status_code == 200
+    team_names = {team["name"] for team in response.json()["teams"]}
+    assert "progress_alpha" not in team_names
+
+
+def test_team_progress_access_control(client, team_headers, progress_setup):
+    # No token
+    response = client.get("/institution/team-progress")
+    assert response.status_code == 401
+
+    # Team tokens are rejected
+    response = client.get("/institution/team-progress", headers=team_headers)
+    assert response.status_code == 403
+
+    # Institution token without an institution id
+    incomplete_token = create_access_token(
+        data={"sub": "progress_institution", "role": "institution"},
+        expires_delta=timedelta(minutes=30),
+    )
+    response = client.get(
+        "/institution/team-progress",
+        headers={"Authorization": f"Bearer {incomplete_token}"},
+    )
+    assert response.status_code == 400

--- a/backend/tests/integration/routes/tutorial/test_tutorial_router.py
+++ b/backend/tests/integration/routes/tutorial/test_tutorial_router.py
@@ -7,6 +7,8 @@ from backend.database.db_models import (
     Exercise,
     ExerciseSubmission,
     ExerciseSubmissionMetadata,
+    League,
+    LeagueTutorial,
     Team,
     Tutorial,
 )
@@ -51,13 +53,19 @@ def count_words(sentence):
 
 @pytest.fixture
 def tutorial_with_exercise(db_session: Session) -> Tutorial:
-    """One tutorial holding two exercises (to check ordering)."""
+    """One tutorial holding two exercises (to check ordering), attached to
+    TeamA's league — teams only see tutorials attached to their league."""
     tutorial = Tutorial(
         title="Test Tutorial",
         description="Tutorial used by the router tests",
     )
     db_session.add(tutorial)
     db_session.flush()
+
+    team_a = db_session.exec(select(Team).where(Team.name == "TeamA")).one()
+    db_session.add(
+        LeagueTutorial(league_id=team_a.league_id, tutorial_id=tutorial.id)
+    )
 
     # Inserted out of order on purpose: order_index must drive the ordering.
     later = Exercise(
@@ -452,3 +460,132 @@ def test_exercise_submission_history(
         "/tutorial/exercise/99999/submissions", headers=team_headers
     )
     assert response.status_code == 404
+
+
+# -- league scoping ---------------------------------------------------------
+
+
+@pytest.fixture
+def unattached_tutorial(db_session: Session) -> Tutorial:
+    """A tutorial (with one exercise) not attached to any league."""
+    tutorial = Tutorial(
+        title="Other League Tutorial",
+        description="Not attached to TeamA's league",
+    )
+    db_session.add(tutorial)
+    db_session.flush()
+    db_session.add(
+        Exercise(
+            tutorial_id=tutorial.id,
+            order_index=0,
+            title="Hidden Exercise",
+            problem_markdown="Hidden problem",
+            starter_code="def hidden():\n    pass\n",
+            entry_function="hidden",
+            test_cases=[{"name": "runs", "args": [], "expected": None}],
+        )
+    )
+    db_session.commit()
+    db_session.refresh(tutorial)
+    return tutorial
+
+
+def test_team_list_scoped_to_league(
+    client, team_headers, auth_headers, tutorial_with_exercise, unattached_tutorial
+):
+    """Teams only see their league's tutorials; admins see the full library."""
+    response = client.get("/tutorial/tutorials", headers=team_headers)
+    assert response.status_code == 200
+    titles = [t["title"] for t in response.json()["tutorials"]]
+    assert titles == ["Test Tutorial"]
+
+    response = client.get("/tutorial/tutorials", headers=auth_headers)
+    assert response.status_code == 200
+    titles = {t["title"] for t in response.json()["tutorials"]}
+    assert titles == {"Test Tutorial", "Other League Tutorial"}
+
+
+def test_team_in_league_without_tutorials_sees_none(
+    client, db_session, tutorial_with_exercise
+):
+    """A team whose league has no attached tutorials gets an empty list and
+    404s on tutorials attached to other leagues."""
+    from backend.tests.conftest import make_student_token
+
+    league = League(
+        name="tutorial_free_league",
+        created_date=utc_now(),
+        expiry_date=utc_now() + timedelta(days=7),
+        game="greedy_pig",
+    )
+    db_session.add(league)
+    db_session.flush()
+    team = Team(
+        name="tutorial_free_team",
+        school_name="Test School",
+        league_id=league.id,
+    )
+    db_session.add(team)
+    db_session.commit()
+    db_session.refresh(team)
+    headers = {"Authorization": f"Bearer {make_student_token(team)}"}
+
+    response = client.get("/tutorial/tutorials", headers=headers)
+    assert response.status_code == 200
+    assert response.json()["tutorials"] == []
+
+    response = client.get(
+        f"/tutorial/tutorial/{tutorial_with_exercise.id}", headers=headers
+    )
+    assert response.status_code == 404
+
+
+def test_unattached_tutorial_hidden_from_team(
+    client, db_session, team_headers, unattached_tutorial
+):
+    """Detail, progress, submit, and submission-history endpoints all 404
+    for a tutorial that isn't attached to the team's league."""
+    exercise = db_session.exec(
+        select(Exercise).where(Exercise.tutorial_id == unattached_tutorial.id)
+    ).one()
+
+    response = client.get(
+        f"/tutorial/tutorial/{unattached_tutorial.id}", headers=team_headers
+    )
+    assert response.status_code == 404
+
+    response = client.get(
+        f"/tutorial/tutorial/{unattached_tutorial.id}/progress",
+        headers=team_headers,
+    )
+    assert response.status_code == 404
+
+    response = client.post(
+        "/tutorial/submit-exercise",
+        json={"exercise_id": exercise.id, "code": PASSING_CODE},
+        headers=team_headers,
+    )
+    assert response.status_code == 404
+    # The blocked attempt is not recorded
+    assert db_session.exec(select(ExerciseSubmissionMetadata)).all() == []
+
+    response = client.get(
+        f"/tutorial/exercise/{exercise.id}/latest-submission",
+        headers=team_headers,
+    )
+    assert response.status_code == 404
+
+    response = client.get(
+        f"/tutorial/exercise/{exercise.id}/submissions", headers=team_headers
+    )
+    assert response.status_code == 404
+
+
+def test_admin_can_open_unattached_tutorial(
+    client, auth_headers, unattached_tutorial
+):
+    response = client.get(
+        f"/tutorial/tutorial/{unattached_tutorial.id}", headers=auth_headers
+    )
+    assert response.status_code == 200
+    assert response.json()["title"] == "Other League Tutorial"

--- a/backend/tests/integration/test_celery_tasks.py
+++ b/backend/tests/integration/test_celery_tasks.py
@@ -55,7 +55,6 @@ class CustomPlayer(Player):
         code=valid_code,
         game_name="prisoners_dilemma",
         team_name=test_team.name,
-        num_simulations=10,
     ).get(timeout=20)
     assert result["status"] == "success"
     assert "simulation_results" in result
@@ -110,7 +109,6 @@ class CustomPlayer(Player):
         code=timeout_code,
         game_name="prisoners_dilemma",
         team_name="timeout_team",
-        num_simulations=10,
     ).get(timeout=15)
     assert result["status"] == "error"
     assert result["message"].startswith("Your agent consumes too much time")
@@ -157,7 +155,6 @@ class CustomPlayer(Player):
         code=contaminating_code,
         game_name="prisoners_dilemma",
         team_name="dirty_team",
-        num_simulations=5,
     ).get(timeout=20)
     assert result["status"] == "success"
 
@@ -165,7 +162,6 @@ class CustomPlayer(Player):
         code=probe_code,
         game_name="prisoners_dilemma",
         team_name="clean_team",
-        num_simulations=5,
     ).get(timeout=20)
     assert result["status"] == "success"
     assert "CLEAN" in (result.get("stdout") or "")

--- a/backend/tests/integration/test_worker_resilience.py
+++ b/backend/tests/integration/test_worker_resilience.py
@@ -88,7 +88,6 @@ def _validate(code: str, team: str):
         code=code,
         game_name="greedy_pig",
         team_name=team,
-        num_simulations=10,
     ).get(timeout=30)
 
 

--- a/backend/tests/services/test_simulation_service.py
+++ b/backend/tests/services/test_simulation_service.py
@@ -1,9 +1,15 @@
 from datetime import timedelta
+from types import SimpleNamespace
 
 import pytest
 from sqlmodel import Session, select
 
-from backend.database.db_models import League
+from backend.database.db_models import (
+    League,
+    Submission,
+    SubmissionMetadata,
+    Team,
+)
 from backend.tasks.simulation_task import aggregate_simulation_results, run_simulation
 from backend.time_utils import utc_now
 
@@ -61,6 +67,165 @@ def test_simulation_task_success(celery_workers, test_league: League):
     ).get(timeout=60)
     assert "feedback" in result
     assert "player_feedback" in result
+
+
+# Direct (in-process) calls of the task function: the .delay() tests above run
+# the body inside a worker container, so only these direct calls give the test
+# process visibility into run_simulation's branches.
+
+COLLUDER_CODE = """
+from games.prisoners_dilemma.player import Player
+
+class CustomPlayer(Player):
+    def make_decision(self, game_state):
+        return 'collude'
+"""
+
+
+class _StubGame:
+    """Minimal game double for exercising run_simulation's error branches."""
+
+    def __init__(self, league):
+        self.players = [object()]
+        self.scores = {}
+
+    def add_player(self, code, name):
+        self.players.append(object())
+
+    def reset(self):
+        pass
+
+    def run_single_game_with_feedback(self, custom_rewards=None):
+        return {"feedback": "stub feedback", "player_feedback": "stub pf"}
+
+    def play_game(self, custom_rewards=None):
+        return {"points": {"stub": 1}, "table": {}}
+
+    def get_player_strategies(self):
+        return {}
+
+
+def _stub_factory(monkeypatch, game_class):
+    monkeypatch.setattr(
+        "backend.tasks.simulation_task.GameFactory",
+        SimpleNamespace(get_game_class=lambda name: game_class),
+    )
+
+
+def test_run_simulation_direct_success(db_session, test_league):
+    """No submissions in the league -> validation players play the games."""
+    result = run_simulation(
+        league_id=test_league.id,
+        game_name="prisoners_dilemma",
+        num_simulations=3,
+    )
+    assert result["status"] == "success"
+    assert result["player_feedback"] == "No player feedback"
+    sim = result["simulation_results"]
+    assert sim["num_simulations"] == 3
+    assert sim["total_points"]  # validation players scored
+    assert "strategies" in sim
+
+
+def test_run_simulation_direct_with_player_feedback(db_session, test_league):
+    result = run_simulation(
+        league_id=test_league.id,
+        game_name="prisoners_dilemma",
+        num_simulations=2,
+        player_feedback=True,
+    )
+    assert result["status"] == "success"
+    assert result["feedback"] != "No feedback"
+
+
+def test_run_simulation_direct_with_submissions(db_session, test_league):
+    """League submissions replace the validation players; a submission whose
+    code cannot construct a player is skipped, not fatal."""
+    now = utc_now()
+    teams = {}
+    for name, code in (("good_team", COLLUDER_CODE), ("broken_team", "not python !")):
+        team = Team(name=name, school_name="Test School", league_id=test_league.id)
+        db_session.add(team)
+        db_session.commit()
+        db_session.refresh(team)
+        meta = SubmissionMetadata(team_id=team.id, league_id=test_league.id, timestamp=now)
+        db_session.add(meta)
+        db_session.commit()
+        db_session.refresh(meta)
+        db_session.add(Submission(code=code, timestamp=now, metadata_id=meta.id))
+        db_session.commit()
+        teams[name] = team
+
+    result = run_simulation(
+        league_id=test_league.id,
+        game_name="prisoners_dilemma",
+        num_simulations=2,
+    )
+    assert result["status"] == "success"
+    points = result["simulation_results"]["total_points"]
+    assert set(points) == {"good_team"}  # broken_team failed construction
+
+
+def test_run_simulation_direct_submission_fetch_error(monkeypatch, db_session, test_league):
+    """A DB error while fetching submissions keeps the validation players."""
+
+    def boom(session, league_id):
+        raise RuntimeError("db unavailable")
+
+    monkeypatch.setattr(
+        "backend.routes.user.user_db.get_latest_submissions_for_league", boom
+    )
+    result = run_simulation(
+        league_id=test_league.id,
+        game_name="prisoners_dilemma",
+        num_simulations=2,
+    )
+    assert result["status"] == "success"
+    assert result["simulation_results"]["total_points"]
+
+
+def test_run_simulation_direct_no_players(monkeypatch, db_session):
+    class NoPlayersGame(_StubGame):
+        def __init__(self, league):
+            super().__init__(league)
+            self.players = []
+
+    _stub_factory(monkeypatch, NoPlayersGame)
+    result = run_simulation(league_id=999_999, game_name="prisoners_dilemma")
+    assert result["status"] == "error"
+    assert result["message"] == "No players loaded for simulation"
+    assert result["simulation_results"]["total_points"] == {}
+
+
+def test_run_simulation_direct_feedback_error(monkeypatch, db_session):
+    class FeedbackErrorGame(_StubGame):
+        def run_single_game_with_feedback(self, custom_rewards=None):
+            raise RuntimeError("feedback exploded")
+
+    _stub_factory(monkeypatch, FeedbackErrorGame)
+    result = run_simulation(
+        league_id=999_999,
+        game_name="prisoners_dilemma",
+        num_simulations=2,
+        player_feedback=True,
+    )
+    assert result["status"] == "error"
+    assert "Error running feedback game" in result["message"]
+
+
+def test_run_simulation_direct_simulation_error(monkeypatch, db_session):
+    class PlayErrorGame(_StubGame):
+        def play_game(self, custom_rewards=None):
+            raise RuntimeError("game exploded")
+
+    _stub_factory(monkeypatch, PlayErrorGame)
+    result = run_simulation(
+        league_id=999_999,
+        game_name="prisoners_dilemma",
+        num_simulations=2,
+    )
+    assert result["status"] == "error"
+    assert "Error running simulations" in result["message"]
 
 
 def test_aggregate_simulation_results_success():

--- a/backend/tests/services/test_validation_service.py
+++ b/backend/tests/services/test_validation_service.py
@@ -22,7 +22,6 @@ def test_validation_task_custom_rewards(celery_workers):
         code=VALID_CODE,
         game_name="prisoners_dilemma",
         team_name="test_team",
-        num_simulations=20,
         custom_rewards=[4, 0, 6, 2],
     ).get(timeout=20)
     assert result["status"] == "success"
@@ -41,7 +40,6 @@ def test_validation_task_invalid_game(celery_workers):
         code=VALID_CODE,
         game_name="invalid_game",
         team_name="test_team",
-        num_simulations=10,
     ).get(timeout=20)
     assert result["status"] == "error"
     assert "Unknown game" in result["message"]

--- a/backend/tests/services/test_validation_service.py
+++ b/backend/tests/services/test_validation_service.py
@@ -118,7 +118,6 @@ class CustomPlayer(Player):
         code=error_code,
         game_name="prisoners_dilemma",
         team_name="test_team",
-        num_simulations=10,
     ).get(timeout=20)
     assert result["status"] == "error"
     assert result["message"].startswith("Error during simulation:")
@@ -140,7 +139,6 @@ class CustomPlayer(Player):
         code=feedback_code,
         game_name="prisoners_dilemma",
         team_name="test_team",
-        num_simulations=10,
     ).get(timeout=20)
     assert result["status"] == "success"
     assert "feedback" in result

--- a/backend/tests/services/test_validation_service.py
+++ b/backend/tests/services/test_validation_service.py
@@ -1,7 +1,16 @@
 import ast
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from celery.exceptions import SoftTimeLimitExceeded, TimeLimitExceeded
 
 from backend.routes.user.code_validation import CodeValidator, validate_code
-from backend.tasks.validation_task import run_validation
+from backend.tasks.validation_task import (
+    TIMEOUT_MESSAGE,
+    await_validation_result,
+    run_validation,
+)
 
 # Test constants
 VALID_CODE = """
@@ -25,6 +34,101 @@ def test_validation_task_custom_rewards(celery_workers):
         custom_rewards=[4, 0, 6, 2],
     ).get(timeout=20)
     assert result["status"] == "success"
+
+
+# Direct (in-process) calls: the .delay() tests run the task body inside a
+# worker container, so only direct calls exercise these branches in-process.
+
+
+def test_run_validation_direct_success_captures_stdout():
+    printing_code = """
+from games.prisoners_dilemma.player import Player
+
+class CustomPlayer(Player):
+    def make_decision(self, game_state):
+        print("thinking...")
+        return 'collude'
+"""
+    result = run_validation(
+        code=printing_code,
+        game_name="prisoners_dilemma",
+        team_name="test_team",
+    )
+    assert result["status"] == "success"
+    assert result["duration_ms"] > 0
+    assert "strategies" in result["simulation_results"]
+    assert "thinking..." in result["stdout"]
+
+
+def test_run_validation_direct_soft_limit_chained():
+    """The soft limit interrupting an agent call is re-raised by the engine as
+    ValueError; the chain walk must still classify the run as a timeout."""
+    slow_code = """
+from games.prisoners_dilemma.player import Player
+from celery.exceptions import SoftTimeLimitExceeded
+
+class CustomPlayer(Player):
+    def make_decision(self, game_state):
+        raise SoftTimeLimitExceeded()
+"""
+    result = run_validation(
+        code=slow_code,
+        game_name="prisoners_dilemma",
+        team_name="test_team",
+    )
+    assert result["status"] == "error"
+    assert result["message"] == TIMEOUT_MESSAGE
+
+
+def test_run_validation_direct_soft_limit_unwrapped(monkeypatch):
+    """A SoftTimeLimitExceeded that escapes unwrapped hits its own handler."""
+
+    class TimeoutGame:
+        validation_simulations = 5
+
+        def __init__(self, league):
+            pass
+
+        def add_player(self, code, name):
+            pass
+
+        def run_single_game_with_feedback(self, custom_rewards=None):
+            raise SoftTimeLimitExceeded()
+
+    monkeypatch.setattr(
+        "backend.tasks.validation_task.GameFactory",
+        SimpleNamespace(get_game_class=lambda name: TimeoutGame),
+    )
+    result = run_validation(
+        code=VALID_CODE,
+        game_name="prisoners_dilemma",
+        team_name="test_team",
+    )
+    assert result["status"] == "error"
+    assert result["message"] == TIMEOUT_MESSAGE
+    assert result["traceback"] is None
+
+
+@pytest.mark.asyncio
+async def test_await_validation_result_timeout_maps_to_timeout_response(monkeypatch):
+    async def boom(async_result, timeout):
+        raise TimeLimitExceeded()
+
+    monkeypatch.setattr("backend.tasks.validation_task.poll_task_result", boom)
+    result = await await_validation_result(MagicMock(), timeout=0.1)
+    assert result["status"] == "error"
+    assert result["message"] == TIMEOUT_MESSAGE
+
+
+@pytest.mark.asyncio
+async def test_await_validation_result_generic_error(monkeypatch):
+    async def boom(async_result, timeout):
+        raise RuntimeError("backend blew up")
+
+    monkeypatch.setattr("backend.tasks.validation_task.poll_task_result", boom)
+    result = await await_validation_result(MagicMock(), timeout=0.1)
+    assert result["status"] == "error"
+    assert result["message"] == "Error during validation: backend blew up"
 
 
 def test_validate_code_syntax_error():

--- a/backend/tests/unit/routes/ai/test_hint_context.py
+++ b/backend/tests/unit/routes/ai/test_hint_context.py
@@ -1,0 +1,178 @@
+"""Unit tests for hint_context: outcome classification, game-source loading,
+and prompt rendering. Pure functions — no DB, no Celery."""
+
+import pytest
+
+from backend.routes.ai.hint_context import (
+    HintContext,
+    _render_feedback,
+    _render_sim_results,
+    _truncate,
+    build_hint_context,
+    build_hint_context_from_response,
+    classify_outcome,
+    load_game_source,
+)
+
+
+# --- classify_outcome --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "status,message,expected",
+    [
+        ("success", None, "success"),
+        ("error", "Syntax error in code: invalid syntax (line 3)", "syntax_error"),
+        ("error", "Your agent consumes too much time - validation did not finish", "timeout"),
+        ("error", "Error initializing game: boom", "init_error"),
+        ("error", "Failed to create player for team X: bad class", "construction_error"),
+        ("error", "Error during simulation: ZeroDivisionError", "runtime_error"),
+        ("error", "Agent code is not safe: unauthorized import os", "unsafe_code"),
+        # The unsafe wrapper is stripped before prefix-matching, so a wrapped
+        # syntax error still classifies as syntax_error.
+        ("error", "Agent code is not safe: Syntax error in code: bad", "syntax_error"),
+        ("error", None, "unknown_error"),
+        ("error", "something novel", "unknown_error"),
+    ],
+)
+def test_classify_outcome(status, message, expected):
+    assert classify_outcome(status, message) == expected
+
+
+# --- load_game_source ---------------------------------------------------------
+
+
+def test_load_game_source_reads_game_package():
+    source = load_game_source("greedy_pig")
+    assert source is not None
+    assert "# ===== backend/games/greedy_pig/greedy_pig.py =====" in source
+    assert "# ===== backend/games/greedy_pig/player.py =====" in source
+    # In-package test files and __init__.py are skipped.
+    assert "test_threshold_calibration" not in source
+
+
+@pytest.mark.parametrize(
+    "name", [None, "", "no_such_game", "../greedy_pig", "greedy.pig", "a/b"]
+)
+def test_load_game_source_rejects_bad_names(name):
+    assert load_game_source(name) is None
+
+
+# --- rendering helpers ---------------------------------------------------------
+
+
+def test_truncate_appends_omitted_count():
+    out = _truncate("x" * 10, 6)
+    assert out.startswith("xxxxxx")
+    assert "[truncated 4 chars]" in out
+    assert _truncate("short", 100) == "short"
+
+
+def test_render_feedback_string_and_none():
+    assert _render_feedback(None) is None
+    assert _render_feedback("   ") is None
+    assert _render_feedback(" result ") == "result"
+
+
+def test_render_feedback_bare_list_is_summarised():
+    assert _render_feedback([]) is None
+    assert _render_feedback([1, 2, 3]) == "[3 blow-by-blow feedback entries omitted]"
+
+
+def test_render_feedback_dict_drops_logs_keeps_aggregates():
+    feedback = {
+        "winner": "team_a",
+        "rounds": [{"n": i} for i in range(50)],  # known log key
+        "big": [list(range(100)) for _ in range(10)],  # oversized list
+    }
+    out = _render_feedback(feedback)
+    assert '"winner": "team_a"' in out
+    assert "[omitted blow-by-blow logs: rounds, big]" in out
+
+
+def test_render_feedback_dict_with_only_logs():
+    out = _render_feedback({"rounds": [1, 2, 3]})
+    assert out == "[omitted blow-by-blow logs: rounds]"
+
+
+def test_render_sim_results():
+    assert _render_sim_results(None) is None
+    assert _render_sim_results({}) is None
+    # strategies/table are noise for hinting and are dropped.
+    assert _render_sim_results({"strategies": {"a": "prose"}, "table": {}}) is None
+    out = _render_sim_results({"total_points": {"a": 5}, "strategies": {}})
+    assert "total_points" in out
+    assert "strategies" not in out
+
+
+# --- HintContext build + render -------------------------------------------------
+
+
+def test_from_validation_response_success_renders_all_sections():
+    result = {
+        "status": "success",
+        "message": None,
+        "feedback": "You won 7 of 10 games.",
+        "simulation_results": {"total_points": {"me": 42}, "strategies": {}},
+        "duration_ms": 123.4,
+        "stdout": "debug print\n",
+    }
+    ctx = HintContext.from_validation_response(
+        "print('hi')", result, game_name="greedy_pig", team_name="me"
+    )
+    assert ctx.category == "success"
+    assert ctx.sim_completed and not ctx.is_syntax_error and not ctx.is_timeout
+    text = str(ctx)
+    assert "Game: greedy_pig" in text
+    assert "Execution time: 123.4 ms" in text
+    assert "--- Captured stdout ---" in text
+    assert "--- Game Feedback ---" in text
+    assert "--- Simulation Results ---" in text
+    assert "--- Game Source Code ---" in text
+    assert "  1: print('hi')" in text
+
+
+def test_from_validation_response_syntax_error_skips_game_source():
+    result = {"status": "error", "message": "Syntax error in code: bad"}
+    ctx = HintContext.from_validation_response(
+        "def f(:", result, game_name="greedy_pig"
+    )
+    assert ctx.is_syntax_error
+    assert ctx.game_source is None
+    text = build_hint_context(ctx)
+    assert "--- Validator Message ---" in text
+    assert "--- Game Source Code ---" not in text
+
+
+def test_from_validation_response_traceback_rendered():
+    result = {
+        "status": "error",
+        "message": "Error during simulation: boom",
+        "traceback": "Traceback (most recent call last): ...",
+    }
+    ctx = HintContext.from_validation_response("code", result, game_name=None)
+    text = build_hint_context(ctx)
+    assert "--- Stack Trace ---" in text
+    assert ctx.category == "runtime_error"
+
+
+def test_from_validation_response_warnings():
+    # Unexpected status and an unloadable game source both surface as notes.
+    ctx = HintContext.from_validation_response(
+        "code", {"status": "weird"}, game_name="no_such_game"
+    )
+    text = build_hint_context(ctx)
+    assert "--- Notes ---" in text
+    assert "Unexpected validator status 'weird'" in text
+    assert "Game source for 'no_such_game' could not be loaded." in text
+
+
+def test_build_hint_context_from_response_one_shot():
+    text = build_hint_context_from_response(
+        "code",
+        {"status": "success"},
+        game_name="greedy_pig",
+        include_game_code=False,
+    )
+    assert text.startswith("=== STUDENT SUBMISSION HINT CONTEXT ===")
+    assert "--- Game Source Code ---" not in text

--- a/frontend/src/AgentGames/Institution/InstitutionProgress.jsx
+++ b/frontend/src/AgentGames/Institution/InstitutionProgress.jsx
@@ -1,0 +1,194 @@
+import React, { useState, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { authFetch } from '../../utils/authFetch';
+import { selectToken } from '../../slices/authSlice';
+
+const formatTimestamp = (ts) => {
+  if (!ts) return '—';
+  const d = new Date(ts);
+  return d.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
+/** Completion bar: passed / total teams, colored by rate. */
+const CompletionBar = ({ passed, total }) => {
+  const pct = total > 0 ? Math.round((passed / total) * 100) : 0;
+  const barColor =
+    pct >= 75 ? 'bg-green-500' : pct >= 40 ? 'bg-yellow-400' : 'bg-red-400';
+  return (
+    <div className="flex items-center gap-3">
+      <div className="flex-1 h-3 bg-gray-200 rounded-full overflow-hidden min-w-[80px]">
+        <div
+          className={`h-full ${barColor} transition-all`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="text-sm font-mono text-ui-dark w-24 text-right">
+        {passed}/{total} ({pct}%)
+      </span>
+    </div>
+  );
+};
+
+function InstitutionProgress() {
+  const apiUrl = useSelector((state) => state.settings.agentApiUrl);
+  const accessToken = useSelector(selectToken);
+
+  const [teams, setTeams] = useState([]);
+  const [tutorials, setTutorials] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const fetchProgress = async () => {
+      if (!accessToken) return;
+      try {
+        setLoading(true);
+        setError('');
+        const response = await authFetch(`${apiUrl}/institution/team-progress`, {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+        const data = await response.json();
+        if (response.ok) {
+          setTeams(data.teams || []);
+          setTutorials(data.tutorials || []);
+        } else {
+          setError(data.detail || 'Failed to load team progress');
+        }
+      } catch (e) {
+        console.error('Error fetching team progress:', e);
+        setError('Error fetching team progress');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchProgress();
+  }, [apiUrl, accessToken]);
+
+  return (
+    <div className="min-h-screen bg-ui-lighter pt-20 px-6 pb-8">
+      <div className="max-w-[1800px] mx-auto space-y-6">
+        {loading ? (
+          <div className="bg-white rounded-lg shadow-lg p-6">
+            <div className="flex justify-center items-center h-32">
+              <div className="text-lg text-ui-dark">Loading team progress...</div>
+            </div>
+          </div>
+        ) : error ? (
+          <div className="bg-white rounded-lg shadow-lg p-6 text-danger">{error}</div>
+        ) : (
+          <>
+            {/* Section 1: team submissions overview */}
+            <div className="bg-white rounded-lg shadow-lg p-6">
+              <h1 className="text-2xl font-bold text-ui-dark mb-6">Team Progress</h1>
+              {teams.length === 0 ? (
+                <p className="text-ui">No teams found for this institution.</p>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full">
+                    <thead>
+                      <tr className="bg-ui-lighter">
+                        <th className="px-4 py-3 text-left text-base font-semibold text-ui-dark">Team</th>
+                        <th className="px-4 py-3 text-left text-base font-semibold text-ui-dark">School</th>
+                        <th className="px-4 py-3 text-left text-base font-semibold text-ui-dark">League</th>
+                        <th className="px-4 py-3 text-right text-base font-semibold text-ui-dark">Attempts</th>
+                        <th className="px-4 py-3 text-right text-base font-semibold text-ui-dark">Validated</th>
+                        <th className="px-4 py-3 text-right text-base font-semibold text-ui-dark">Hints Used</th>
+                        <th className="px-4 py-3 text-left text-base font-semibold text-ui-dark">Last Submission</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {teams.map((team) => (
+                        <tr key={team.id} className="border-b border-ui-light hover:bg-ui-lighter/50">
+                          <td className="px-4 py-3 text-base font-medium text-ui-dark">{team.name}</td>
+                          <td className="px-4 py-3 text-base text-ui">{team.school}</td>
+                          <td className="px-4 py-3 text-base text-ui">{team.league || '—'}</td>
+                          <td className="px-4 py-3 text-base text-right font-mono text-ui-dark">{team.total_attempts}</td>
+                          <td className="px-4 py-3 text-base text-right font-mono text-ui-dark">{team.validated_submissions}</td>
+                          <td className="px-4 py-3 text-base text-right font-mono text-ui-dark">{team.hints_used}</td>
+                          <td className="px-4 py-3 text-base text-ui">{formatTimestamp(team.latest_submission)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+
+            {/* Section 2: per-tutorial exercise completion */}
+            <div className="bg-white rounded-lg shadow-lg p-6">
+              <h2 className="text-2xl font-bold text-ui-dark mb-2">Tutorial Progress</h2>
+              <p className="text-ui mb-6">
+                Completion rate per exercise across the teams in each tutorial's leagues.
+              </p>
+              {tutorials.length === 0 ? (
+                <p className="text-ui">
+                  No tutorials are attached to your leagues yet. Attach tutorials from League Management.
+                </p>
+              ) : (
+                <div className="space-y-8">
+                  {tutorials.map((tutorial) => (
+                    <div key={tutorial.id}>
+                      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 mb-3">
+                        <h3 className="text-xl font-semibold text-ui-dark">{tutorial.title}</h3>
+                        <span className="text-sm text-ui">
+                          {tutorial.team_count} team{tutorial.team_count !== 1 ? 's' : ''}
+                          {tutorial.league_names.length > 0 &&
+                            ` · leagues: ${tutorial.league_names.join(', ')}`}
+                        </span>
+                      </div>
+                      {tutorial.exercises.length === 0 ? (
+                        <p className="text-ui text-sm">This tutorial has no exercises yet.</p>
+                      ) : (
+                        <div className="overflow-x-auto">
+                          <table className="w-full">
+                            <thead>
+                              <tr className="bg-ui-lighter">
+                                <th className="px-4 py-2 text-left text-sm font-semibold text-ui-dark w-12">#</th>
+                                <th className="px-4 py-2 text-left text-sm font-semibold text-ui-dark">Exercise</th>
+                                <th className="px-4 py-2 text-right text-sm font-semibold text-ui-dark w-28">Attempted</th>
+                                <th className="px-4 py-2 text-right text-sm font-semibold text-ui-dark w-24">Passed</th>
+                                <th className="px-4 py-2 text-left text-sm font-semibold text-ui-dark w-72">Completion</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {tutorial.exercises.map((exercise, index) => (
+                                <tr key={exercise.id} className="border-b border-ui-light hover:bg-ui-lighter/50">
+                                  <td className="px-4 py-2 text-sm font-mono text-ui">{index + 1}</td>
+                                  <td className="px-4 py-2 text-base text-ui-dark">{exercise.title}</td>
+                                  <td className="px-4 py-2 text-sm text-right font-mono text-ui-dark">
+                                    {exercise.attempted_count}/{tutorial.team_count}
+                                  </td>
+                                  <td className="px-4 py-2 text-sm text-right font-mono text-ui-dark">
+                                    {exercise.passed_count}/{tutorial.team_count}
+                                  </td>
+                                  <td className="px-4 py-2">
+                                    <CompletionBar
+                                      passed={exercise.passed_count}
+                                      total={tutorial.team_count}
+                                    />
+                                  </td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default InstitutionProgress;

--- a/frontend/src/AgentGames/Shared/League/LeagueAttributes.jsx
+++ b/frontend/src/AgentGames/Shared/League/LeagueAttributes.jsx
@@ -16,6 +16,7 @@ import { authFetch } from '../../../utils/authFetch';
 // Import shared components
 import LeagueTeams from './LeagueTeams';
 import LeagueCreation from './LeagueCreation';
+import LeagueTutorials from './LeagueTutorials';
 import LeagueCardList from "./LeagueCardList";
 import PureMarkdown from '../Utilities/PureMarkdown';
 import useLeagueAPI from '../hooks/useLeagueAPI';
@@ -405,6 +406,12 @@ const LeagueAttributes = ({ userRole, redirectPath, onUnauthorized }) => {
                     )}
                   </div>
                 </div>
+
+                {/* League Tutorials */}
+                <LeagueTutorials
+                  leagueId={currentLeague.id}
+                  userRole={userRole}
+                />
 
                 {/* Teams Grid */}
                 <LeagueTeams

--- a/frontend/src/AgentGames/Shared/League/LeagueCreation.jsx
+++ b/frontend/src/AgentGames/Shared/League/LeagueCreation.jsx
@@ -5,21 +5,34 @@ import "react-datepicker/dist/react-datepicker.css";
 import { toast } from "react-toastify";
 import { authFetch } from "../../../utils/authFetch";
 import { selectToken } from '../../../slices/authSlice';
+import LeagueTutorialSelector from "./LeagueTutorialSelector";
+import useLeagueAPI from "../hooks/useLeagueAPI";
 
-const LeagueCreation = () => {
+const EMPTY_FORM = {
+  leagueName: "",
+  gameName: "",
+  selectedDate: null,
+  schoolLeague: false,
+  schoolsSource: "static",
+  schoolsText: "",
+  sheetUrl: "",
+  tutorialIds: [],
+};
+
+/**
+ * "Create New League" button that opens the creation form in a modal.
+ * The form covers name, game, school-league settings, expiry, and which
+ * tutorials the league's teams will see. After a successful creation the
+ * modal shows the signup link until dismissed.
+ */
+const LeagueCreation = ({ userRole }) => {
   const token = useSelector(selectToken);
   const apiUrl = useSelector((state) => state.settings.agentApiUrl);
+  const { fetchUserLeagues } = useLeagueAPI(userRole);
 
+  const [isOpen, setIsOpen] = useState(false);
   const [games, setGames] = useState([]);
-  const [leagueInfo, setLeagueInfo] = useState({
-    leagueName: "",
-    gameName: "",
-    selectedDate: null,
-    schoolLeague: false,
-    schoolsSource: "static",
-    schoolsText: "",
-    sheetUrl: "",
-  });
+  const [leagueInfo, setLeagueInfo] = useState(EMPTY_FORM);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
   const [signupUrl, setSignupUrl] = useState("");
@@ -73,7 +86,11 @@ const LeagueCreation = () => {
       [name]: type === "checkbox" ? checked : value,
     }));
     setError("");
-    setSignupUrl(""); // Clear previous signup URL when form changes
+  };
+
+  const handleTutorialsChange = (tutorialIds) => {
+    setLeagueInfo((prev) => ({ ...prev, tutorialIds }));
+    setError("");
   };
 
   const parseSchools = (text) =>
@@ -88,7 +105,14 @@ const LeagueCreation = () => {
       selectedDate: date,
     }));
     setError("");
-    setSignupUrl(""); // Clear previous signup URL when form changes
+  };
+
+  const closeModal = () => {
+    setIsOpen(false);
+    setError("");
+    setSignupUrl("");
+    setCreatedSchoolLeague(false);
+    setLeagueInfo({ ...EMPTY_FORM, gameName: games[0] || "" });
   };
 
   const validateForm = () => {
@@ -154,6 +178,7 @@ const LeagueCreation = () => {
             leagueInfo.schoolLeague && leagueInfo.schoolsSource === "sheet"
               ? leagueInfo.sheetUrl.trim()
               : null,
+          tutorial_ids: leagueInfo.tutorialIds,
         }),
       });
 
@@ -161,6 +186,7 @@ const LeagueCreation = () => {
 
       if (response.ok) {
         toast.success("League created successfully!");
+        fetchUserLeagues();
 
         // Create the signup URL from the signup token
         if (data.signup_token) {
@@ -169,18 +195,12 @@ const LeagueCreation = () => {
           const signupPath = `/TeamSignup/${data.signup_token}`;
           setSignupUrl(`${baseUrl}${signupPath}`);
           setCreatedSchoolLeague(Boolean(data.school_league));
+        } else {
+          closeModal();
         }
 
         // Reset form after successful creation
-        setLeagueInfo({
-          leagueName: "",
-          gameName: games[0] || "",
-          selectedDate: null,
-          schoolLeague: false,
-          schoolsSource: "static",
-          schoolsText: "",
-          sheetUrl: "",
-        });
+        setLeagueInfo({ ...EMPTY_FORM, gameName: games[0] || "" });
       } else {
         setError(data.detail || "Failed to create league");
       }
@@ -195,217 +215,282 @@ const LeagueCreation = () => {
   return (
     <div className="bg-white rounded-lg shadow-lg p-6">
       <h2 className="text-xl font-bold text-ui-dark mb-4">Create New League</h2>
-
-      <div className="mb-4">
-        <label htmlFor="leagueName" className="block text-ui-dark mb-1">
-          League Name
-        </label>
-        <input
-          type="text"
-          id="leagueName"
-          name="leagueName"
-          value={leagueInfo.leagueName}
-          onChange={handleChange}
-          className="w-full p-2 border border-ui-light rounded"
-          placeholder="Enter league name"
-        />
-      </div>
-
-      <div className="mb-4">
-        <label htmlFor="gameName" className="block text-ui-dark mb-1">
-          Game
-        </label>
-        <select
-          id="gameName"
-          name="gameName"
-          value={leagueInfo.gameName}
-          onChange={handleChange}
-          className="w-full p-2 border border-ui-light rounded"
-        >
-          <option value="" disabled>
-            Select a game
-          </option>
-          {games.map((game, index) => (
-            <option key={index} value={game}>
-              {game}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      <div className="mb-4 flex items-center">
-        <input
-          type="checkbox"
-          id="schoolLeague"
-          name="schoolLeague"
-          checked={leagueInfo.schoolLeague}
-          onChange={handleChange}
-          className="mr-2"
-        />
-        <label htmlFor="schoolLeague" className="text-ui-dark">
-          School league (students pick their school from a dropdown; team names
-          auto-generated; no email, no password recovery)
-        </label>
-      </div>
-
-      {leagueInfo.schoolLeague && (
-        <div className="mb-4 border border-ui-light rounded p-3">
-          <div className="mb-3 flex gap-4">
-            <label className="flex items-center">
-              <input
-                type="radio"
-                name="schoolsSource"
-                value="static"
-                checked={leagueInfo.schoolsSource === "static"}
-                onChange={handleChange}
-                className="mr-2"
-              />
-              Paste list
-            </label>
-            <label className="flex items-center">
-              <input
-                type="radio"
-                name="schoolsSource"
-                value="sheet"
-                checked={leagueInfo.schoolsSource === "sheet"}
-                onChange={handleChange}
-                className="mr-2"
-              />
-              Google Sheet URL
-            </label>
-          </div>
-
-          {leagueInfo.schoolsSource === "static" ? (
-            <>
-              <label htmlFor="schoolsText" className="block text-ui-dark mb-1">
-                Schools (one per line)
-              </label>
-              <textarea
-                id="schoolsText"
-                name="schoolsText"
-                rows={6}
-                value={leagueInfo.schoolsText}
-                onChange={handleChange}
-                className="w-full p-2 border border-ui-light rounded font-mono text-sm"
-                placeholder={"Willetton SHS\nPerth Modern\nApplecross SHS"}
-              />
-              <p className="text-sm text-ui mt-1">
-                Students will pick from this list at signup. At least one
-                school is required.
-              </p>
-            </>
-          ) : (
-            <>
-              <label htmlFor="sheetUrl" className="block text-ui-dark mb-1">
-                Google Sheet URL
-              </label>
-              <input
-                id="sheetUrl"
-                name="sheetUrl"
-                type="text"
-                value={leagueInfo.sheetUrl}
-                onChange={handleChange}
-                className="w-full p-2 border border-ui-light rounded font-mono text-sm"
-                placeholder="https://docs.google.com/spreadsheets/d/..."
-              />
-              <p className="text-sm text-ui mt-1">
-                Share the sheet as <strong>Anyone with the link &mdash; Viewer</strong>.
-                Put school names in column A; the first row is treated as a
-                header. The list refreshes automatically every 5 minutes.
-              </p>
-            </>
-          )}
-
-          <p className="text-sm text-ui mt-3">
-            Remind students to save their passwords &mdash; there is no
-            recovery.
-          </p>
-        </div>
-      )}
-
-      <div className="mb-4">
-        <label htmlFor="expiryDate" className="block text-ui-dark mb-1">
-          Expiry Date (Optional)
-        </label>
-        <DatePicker
-          id="expiryDate"
-          selected={leagueInfo.selectedDate}
-          onChange={handleDateChange}
-          showTimeSelect
-          dateFormat="MMMM d, yyyy h:mm aa"
-          className="w-full p-2 border border-ui-light rounded"
-          placeholderText="Select an expiry date and time"
-          minDate={new Date()}
-        />
-        <p className="text-sm text-ui mt-1">
-          If not specified, the league will expire in 24 hours.
-        </p>
-      </div>
-
-      {error && (
-        <div className="mb-4 p-2 bg-danger-light text-danger rounded">
-          {error}
-        </div>
-      )}
-
+      <p className="text-sm text-ui mb-4">
+        Set up the game, signup options, and the tutorials teams in the league
+        will see.
+      </p>
       <button
-        onClick={handleAddLeague}
-        disabled={isLoading}
-        className="py-2 px-4 bg-primary hover:bg-primary-hover text-white rounded transition-colors disabled:bg-ui-light"
+        onClick={() => setIsOpen(true)}
+        className="w-full py-2 px-4 bg-primary hover:bg-primary-hover text-white rounded transition-colors"
       >
-        {isLoading ? "Creating..." : "Create League"}
+        Create League
       </button>
 
-      {signupUrl && (
-        <div className="mt-4 p-4 bg-success-light rounded-lg">
-          <h4 className="font-medium text-success mb-2">
-            League Created Successfully
-          </h4>
-          <p className="text-sm text-ui-dark mb-2">
-            Share this link for teams to sign up directly:
-          </p>
-          <div className="flex items-center">
-            <input
-              type="text"
-              value={signupUrl}
-              readOnly
-              className="flex-1 p-2 border border-ui-light rounded-lg text-sm bg-white"
-            />
-            <button
-              onClick={() => {
-                navigator.clipboard.writeText(signupUrl);
-                toast.success("Signup URL copied to clipboard!");
-              }}
-              className="ml-2 p-2 bg-primary hover:bg-primary-hover text-white rounded-lg"
-              title="Copy to clipboard"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                className="h-5 w-5"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
+      {isOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+          <div className="bg-white rounded-lg shadow-xl max-w-lg w-full max-h-[90vh] overflow-y-auto p-6">
+            <div className="flex justify-between items-center mb-4">
+              <h2 className="text-xl font-bold text-ui-dark">
+                Create New League
+              </h2>
+              <button
+                onClick={closeModal}
+                className="text-ui-dark/60 hover:text-ui-dark text-2xl leading-none"
+                aria-label="Close"
               >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
-                />
-              </svg>
-            </button>
+                &times;
+              </button>
+            </div>
+
+            {signupUrl ? (
+              <div className="p-4 bg-success-light rounded-lg">
+                <h4 className="font-medium text-success mb-2">
+                  League Created Successfully
+                </h4>
+                <p className="text-sm text-ui-dark mb-2">
+                  Share this link for teams to sign up directly:
+                </p>
+                <div className="flex items-center">
+                  <input
+                    type="text"
+                    value={signupUrl}
+                    readOnly
+                    className="flex-1 p-2 border border-ui-light rounded-lg text-sm bg-white"
+                  />
+                  <button
+                    onClick={() => {
+                      navigator.clipboard.writeText(signupUrl);
+                      toast.success("Signup URL copied to clipboard!");
+                    }}
+                    className="ml-2 p-2 bg-primary hover:bg-primary-hover text-white rounded-lg"
+                    title="Copy to clipboard"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="h-5 w-5"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+                <p className="mt-2 text-sm text-ui-dark">
+                  Teams who use this link will be directly assigned to this
+                  league upon signup.
+                </p>
+                {createdSchoolLeague && (
+                  <p className="mt-2 text-sm text-danger font-medium">
+                    School league: tell students to save their passwords. There
+                    is no recovery &mdash; if they lose it they will need to
+                    sign up again under a new team number.
+                  </p>
+                )}
+                <button
+                  onClick={closeModal}
+                  className="mt-4 w-full py-2 px-4 bg-primary hover:bg-primary-hover text-white rounded transition-colors"
+                >
+                  Done
+                </button>
+              </div>
+            ) : (
+              <>
+                <div className="mb-4">
+                  <label htmlFor="leagueName" className="block text-ui-dark mb-1">
+                    League Name
+                  </label>
+                  <input
+                    type="text"
+                    id="leagueName"
+                    name="leagueName"
+                    value={leagueInfo.leagueName}
+                    onChange={handleChange}
+                    className="w-full p-2 border border-ui-light rounded"
+                    placeholder="Enter league name"
+                  />
+                </div>
+
+                <div className="mb-4">
+                  <label htmlFor="gameName" className="block text-ui-dark mb-1">
+                    Game
+                  </label>
+                  <select
+                    id="gameName"
+                    name="gameName"
+                    value={leagueInfo.gameName}
+                    onChange={handleChange}
+                    className="w-full p-2 border border-ui-light rounded"
+                  >
+                    <option value="" disabled>
+                      Select a game
+                    </option>
+                    {games.map((game, index) => (
+                      <option key={index} value={game}>
+                        {game}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="mb-4">
+                  <label className="block text-ui-dark mb-1">Tutorials</label>
+                  <p className="text-sm text-ui mb-2">
+                    Teams in this league will only see the tutorials selected
+                    here. Leave empty for no tutorials.
+                  </p>
+                  <LeagueTutorialSelector
+                    selectedIds={leagueInfo.tutorialIds}
+                    onChange={handleTutorialsChange}
+                  />
+                </div>
+
+                <div className="mb-4 flex items-center">
+                  <input
+                    type="checkbox"
+                    id="schoolLeague"
+                    name="schoolLeague"
+                    checked={leagueInfo.schoolLeague}
+                    onChange={handleChange}
+                    className="mr-2"
+                  />
+                  <label htmlFor="schoolLeague" className="text-ui-dark">
+                    School league (students pick their school from a dropdown;
+                    team names auto-generated; no email, no password recovery)
+                  </label>
+                </div>
+
+                {leagueInfo.schoolLeague && (
+                  <div className="mb-4 border border-ui-light rounded p-3">
+                    <div className="mb-3 flex gap-4">
+                      <label className="flex items-center">
+                        <input
+                          type="radio"
+                          name="schoolsSource"
+                          value="static"
+                          checked={leagueInfo.schoolsSource === "static"}
+                          onChange={handleChange}
+                          className="mr-2"
+                        />
+                        Paste list
+                      </label>
+                      <label className="flex items-center">
+                        <input
+                          type="radio"
+                          name="schoolsSource"
+                          value="sheet"
+                          checked={leagueInfo.schoolsSource === "sheet"}
+                          onChange={handleChange}
+                          className="mr-2"
+                        />
+                        Google Sheet URL
+                      </label>
+                    </div>
+
+                    {leagueInfo.schoolsSource === "static" ? (
+                      <>
+                        <label
+                          htmlFor="schoolsText"
+                          className="block text-ui-dark mb-1"
+                        >
+                          Schools (one per line)
+                        </label>
+                        <textarea
+                          id="schoolsText"
+                          name="schoolsText"
+                          rows={6}
+                          value={leagueInfo.schoolsText}
+                          onChange={handleChange}
+                          className="w-full p-2 border border-ui-light rounded font-mono text-sm"
+                          placeholder={"Willetton SHS\nPerth Modern\nApplecross SHS"}
+                        />
+                        <p className="text-sm text-ui mt-1">
+                          Students will pick from this list at signup. At least
+                          one school is required.
+                        </p>
+                      </>
+                    ) : (
+                      <>
+                        <label
+                          htmlFor="sheetUrl"
+                          className="block text-ui-dark mb-1"
+                        >
+                          Google Sheet URL
+                        </label>
+                        <input
+                          id="sheetUrl"
+                          name="sheetUrl"
+                          type="text"
+                          value={leagueInfo.sheetUrl}
+                          onChange={handleChange}
+                          className="w-full p-2 border border-ui-light rounded font-mono text-sm"
+                          placeholder="https://docs.google.com/spreadsheets/d/..."
+                        />
+                        <p className="text-sm text-ui mt-1">
+                          Share the sheet as{" "}
+                          <strong>Anyone with the link &mdash; Viewer</strong>.
+                          Put school names in column A; the first row is treated
+                          as a header. The list refreshes automatically every 5
+                          minutes.
+                        </p>
+                      </>
+                    )}
+
+                    <p className="text-sm text-ui mt-3">
+                      Remind students to save their passwords &mdash; there is
+                      no recovery.
+                    </p>
+                  </div>
+                )}
+
+                <div className="mb-4">
+                  <label htmlFor="expiryDate" className="block text-ui-dark mb-1">
+                    Expiry Date (Optional)
+                  </label>
+                  <DatePicker
+                    id="expiryDate"
+                    selected={leagueInfo.selectedDate}
+                    onChange={handleDateChange}
+                    showTimeSelect
+                    dateFormat="MMMM d, yyyy h:mm aa"
+                    className="w-full p-2 border border-ui-light rounded"
+                    placeholderText="Select an expiry date and time"
+                    minDate={new Date()}
+                  />
+                  <p className="text-sm text-ui mt-1">
+                    If not specified, the league will expire in 24 hours.
+                  </p>
+                </div>
+
+                {error && (
+                  <div className="mb-4 p-2 bg-danger-light text-danger rounded">
+                    {error}
+                  </div>
+                )}
+
+                <div className="flex gap-2">
+                  <button
+                    onClick={handleAddLeague}
+                    disabled={isLoading}
+                    className="flex-1 py-2 px-4 bg-primary hover:bg-primary-hover text-white rounded transition-colors disabled:bg-ui-light"
+                  >
+                    {isLoading ? "Creating..." : "Create League"}
+                  </button>
+                  <button
+                    onClick={closeModal}
+                    className="py-2 px-4 bg-ui-light hover:bg-ui-light/80 text-ui-dark rounded transition-colors"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </>
+            )}
           </div>
-          <p className="mt-2 text-sm text-ui-dark">
-            Teams who use this link will be directly assigned to this league
-            upon signup.
-          </p>
-          {createdSchoolLeague && (
-            <p className="mt-2 text-sm text-danger font-medium">
-              School league: tell students to save their passwords. There is no
-              recovery &mdash; if they lose it they will need to sign up again
-              under a new team number.
-            </p>
-          )}
         </div>
       )}
     </div>

--- a/frontend/src/AgentGames/Shared/League/LeagueTutorialSelector.jsx
+++ b/frontend/src/AgentGames/Shared/League/LeagueTutorialSelector.jsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useState } from "react";
+import useTutorialAPI from "../hooks/useTutorialAPI";
+
+/**
+ * Checkbox list of every tutorial in the library, for attaching tutorials to
+ * a league. Controlled: the parent owns `selectedIds` and receives the full
+ * updated array via `onChange`. Admin/institution tokens see the whole
+ * library from /tutorial/tutorials.
+ */
+function LeagueTutorialSelector({ selectedIds, onChange, disabled = false }) {
+  const { getTutorials } = useTutorialAPI();
+  const [tutorials, setTutorials] = useState(null); // null = still loading
+  const [loadError, setLoadError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      const result = await getTutorials();
+      if (cancelled) return;
+      if (result.success) {
+        setTutorials(result.tutorials);
+      } else {
+        setLoadError(result.error || "Failed to load tutorials");
+        setTutorials([]);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const toggle = (tutorialId) => {
+    if (selectedIds.includes(tutorialId)) {
+      onChange(selectedIds.filter((id) => id !== tutorialId));
+    } else {
+      onChange([...selectedIds, tutorialId]);
+    }
+  };
+
+  if (tutorials === null) {
+    return <p className="text-sm text-ui">Loading tutorials...</p>;
+  }
+  if (loadError) {
+    return <p className="text-sm text-danger">{loadError}</p>;
+  }
+  if (tutorials.length === 0) {
+    return (
+      <p className="text-sm text-ui">
+        No tutorials exist yet. Admins can create them under Tutorials.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2 max-h-48 overflow-y-auto border border-ui-light rounded p-3">
+      {tutorials.map((tutorial) => (
+        <label
+          key={tutorial.id}
+          className="flex items-start gap-2 cursor-pointer"
+        >
+          <input
+            type="checkbox"
+            checked={selectedIds.includes(tutorial.id)}
+            onChange={() => toggle(tutorial.id)}
+            disabled={disabled}
+            className="mt-1"
+          />
+          <span className="min-w-0">
+            <span className="block text-ui-dark font-medium">
+              {tutorial.title}
+            </span>
+            <span className="block text-sm text-ui">
+              {tutorial.exercise_count}{" "}
+              {tutorial.exercise_count === 1 ? "exercise" : "exercises"}
+            </span>
+          </span>
+        </label>
+      ))}
+    </div>
+  );
+}
+
+export default LeagueTutorialSelector;

--- a/frontend/src/AgentGames/Shared/League/LeagueTutorials.jsx
+++ b/frontend/src/AgentGames/Shared/League/LeagueTutorials.jsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from "react";
+import LeagueTutorialSelector from "./LeagueTutorialSelector";
+import useLeagueAPI from "../hooks/useLeagueAPI";
+
+/**
+ * "Tutorials" section for an existing league: shows which tutorials are
+ * attached (i.e. visible to the league's teams) and lets admins/institutions
+ * change the set. Saving replaces the league's whole attachment list.
+ */
+function LeagueTutorials({ leagueId, userRole }) {
+  const { getLeagueTutorials, updateLeagueTutorials } = useLeagueAPI(userRole);
+
+  const [selectedIds, setSelectedIds] = useState([]);
+  const [savedIds, setSavedIds] = useState([]);
+  const [isSaving, setIsSaving] = useState(false);
+  const [loadError, setLoadError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      setLoadError("");
+      const result = await getLeagueTutorials(leagueId);
+      if (cancelled) return;
+      if (result.success) {
+        setSelectedIds(result.tutorialIds);
+        setSavedIds(result.tutorialIds);
+      } else {
+        setLoadError(result.error || "Failed to load league tutorials");
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [leagueId]);
+
+  const hasChanges =
+    [...selectedIds].sort().join(",") !== [...savedIds].sort().join(",");
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    const result = await updateLeagueTutorials(leagueId, selectedIds);
+    if (result.success) {
+      setSavedIds(result.tutorialIds);
+      setSelectedIds(result.tutorialIds);
+    }
+    setIsSaving(false);
+  };
+
+  return (
+    <div className="mb-6">
+      <div className="flex justify-between items-center mb-2">
+        <h3 className="text-lg font-medium text-ui-dark">Tutorials</h3>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={!hasChanges || isSaving}
+          className="px-3 py-1 text-sm bg-primary hover:bg-primary-hover text-white rounded disabled:bg-ui-light disabled:cursor-not-allowed"
+        >
+          {isSaving ? "Saving..." : "Save Tutorials"}
+        </button>
+      </div>
+      <p className="text-sm text-ui mb-2">
+        Teams in this league only see the tutorials selected here.
+      </p>
+      {loadError ? (
+        <p className="text-sm text-danger">{loadError}</p>
+      ) : (
+        <LeagueTutorialSelector
+          selectedIds={selectedIds}
+          onChange={setSelectedIds}
+          disabled={isSaving}
+        />
+      )}
+    </div>
+  );
+}
+
+export default LeagueTutorials;

--- a/frontend/src/AgentGames/Shared/hooks/useLeagueAPI.js
+++ b/frontend/src/AgentGames/Shared/hooks/useLeagueAPI.js
@@ -348,6 +348,64 @@ export const useLeagueAPI = (userRole) => {
   }, [apiUrl, accessToken, dispatch]);
 
   /**
+   * Get the ids of the tutorials attached to a league
+   */
+  const getLeagueTutorials = useCallback(async (leagueId) => {
+    try {
+      const response = await authFetch(`${apiUrl}/institution/get-league-tutorials`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({ league_id: leagueId }),
+      });
+
+      const data = await response.json();
+
+      if (response.ok && Array.isArray(data.tutorial_ids)) {
+        return { success: true, tutorialIds: data.tutorial_ids };
+      }
+      return { success: false, error: data.detail || 'Failed to load league tutorials' };
+    } catch (error) {
+      console.error('Error loading league tutorials:', error);
+      return { success: false, error: 'Network error' };
+    }
+  }, [apiUrl, accessToken]);
+
+  /**
+   * Replace the set of tutorials attached to a league
+   */
+  const updateLeagueTutorials = useCallback(async (leagueId, tutorialIds) => {
+    setIsLoading(true);
+    try {
+      const response = await authFetch(`${apiUrl}/institution/update-league-tutorials`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({ league_id: leagueId, tutorial_ids: tutorialIds }),
+      });
+
+      const data = await response.json();
+
+      if (response.ok) {
+        toast.success(data.message);
+        return { success: true, tutorialIds: data.tutorial_ids };
+      }
+      toast.error(data.detail || 'Failed to update league tutorials');
+      return { success: false, error: data.detail };
+    } catch (error) {
+      console.error('Error updating league tutorials:', error);
+      toast.error('Network error while updating league tutorials');
+      return { success: false, error: 'Network error' };
+    } finally {
+      setIsLoading(false);
+    }
+  }, [apiUrl, accessToken]);
+
+  /**
    * Assign team to league
    */
   const assignTeamToLeague = useCallback(async (teamId, leagueId) => {
@@ -496,6 +554,8 @@ export const useLeagueAPI = (userRole) => {
     publishResults,
     updateExpiryDate,
     updateLeagueInfo,
+    getLeagueTutorials,
+    updateLeagueTutorials,
     assignTeamToLeague,
     unassignTeam,
     deleteLeague,

--- a/frontend/src/AgentGames/User/Tutorial.jsx
+++ b/frontend/src/AgentGames/User/Tutorial.jsx
@@ -5,22 +5,71 @@ import TutorialOverview from "./TutorialOverview";
 import useTutorialAPI from "../Shared/hooks/useTutorialAPI";
 
 /**
- * Tutorial page. Two views driven by the `exercise` search param:
- * without it, an overview listing the tutorial's exercises in order with the
- * team's progress; with it, the selected exercise in the shared submission
- * workspace, with back/previous/next navigation in the panel header. Keeping
- * the selection in the URL makes refresh and browser-back behave.
+ * Tutorial page. The backend only returns the tutorials attached to the
+ * team's league, so the page adapts to how many there are:
+ * - none: an empty state
+ * - one: straight into that tutorial (today's behaviour)
+ * - many: a picker list first, with the chosen tutorial in the `tutorial`
+ *   search param
+ * Within a tutorial the `exercise` search param drives overview vs. exercise
+ * workspace, as before. Keeping both selections in the URL makes refresh and
+ * browser-back behave.
  */
 function Tutorial() {
   const { getTutorials, getTutorial, getTutorialProgress } = useTutorialAPI();
   const [searchParams, setSearchParams] = useSearchParams();
 
+  const [tutorials, setTutorials] = useState(null); // null = list loading
   const [tutorial, setTutorial] = useState(null);
   const [progressByExerciseId, setProgressByExerciseId] = useState({});
   const [loadError, setLoadError] = useState(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingDetail, setIsLoadingDetail] = useState(false);
 
+  const selectedTutorialId = Number(searchParams.get("tutorial")) || null;
   const selectedExerciseId = Number(searchParams.get("exercise")) || null;
+
+  // With exactly one tutorial there is nothing to pick: open it directly.
+  const effectiveTutorialId =
+    selectedTutorialId ??
+    (tutorials && tutorials.length === 1 ? tutorials[0].id : null);
+
+  useEffect(() => {
+    const loadList = async () => {
+      const result = await getTutorials();
+      if (result.success) {
+        setTutorials(result.tutorials);
+      } else {
+        setLoadError(result.error);
+        setTutorials([]);
+      }
+    };
+    loadList();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!effectiveTutorialId) {
+      setTutorial(null);
+      return;
+    }
+    let cancelled = false;
+    const loadDetail = async () => {
+      setIsLoadingDetail(true);
+      const result = await getTutorial(effectiveTutorialId);
+      if (cancelled) return;
+      if (result.success) {
+        setTutorial(result.tutorial);
+      } else {
+        setLoadError(result.error);
+      }
+      setIsLoadingDetail(false);
+    };
+    loadDetail();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [effectiveTutorialId]);
 
   const loadProgress = useCallback(
     async (tutorialId) => {
@@ -34,34 +83,6 @@ function Tutorial() {
     [getTutorialProgress]
   );
 
-  useEffect(() => {
-    const loadTutorial = async () => {
-      const listResult = await getTutorials();
-      if (!listResult.success) {
-        setLoadError(listResult.error);
-        setIsLoading(false);
-        return;
-      }
-      if (listResult.tutorials.length === 0) {
-        setIsLoading(false);
-        return;
-      }
-
-      const detailResult = await getTutorial(listResult.tutorials[0].id);
-      if (!detailResult.success) {
-        setLoadError(detailResult.error);
-        setIsLoading(false);
-        return;
-      }
-
-      setTutorial(detailResult.tutorial);
-      setIsLoading(false);
-    };
-
-    loadTutorial();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   // Fetch progress whenever the overview is (re)shown, so an exercise passed
   // in the workspace is marked completed the moment the student comes back.
   useEffect(() => {
@@ -70,7 +91,7 @@ function Tutorial() {
     }
   }, [tutorial, selectedExerciseId, loadProgress]);
 
-  if (isLoading) {
+  if (tutorials === null || (effectiveTutorialId && isLoadingDetail && !tutorial)) {
     return (
       <div className="min-h-screen pt-12 flex items-center justify-center bg-white">
         <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-primary"></div>
@@ -79,18 +100,107 @@ function Tutorial() {
     );
   }
 
-  if (loadError || !tutorial || tutorial.exercises.length === 0) {
+  if (loadError) {
     return (
       <div className="min-h-screen pt-12 flex items-center justify-center bg-white">
         <div className="text-center p-8 text-ui">
-          <p className="text-xl">
-            {loadError || "No tutorial is available yet."}
-          </p>
+          <p className="text-xl">{loadError}</p>
+          <p className="text-sm mt-2">Please try again later.</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (tutorials.length === 0) {
+    return (
+      <div className="min-h-screen pt-12 flex items-center justify-center bg-white">
+        <div className="text-center p-8 text-ui">
+          <p className="text-xl">Your league doesn't have any tutorials yet.</p>
           <p className="text-sm mt-2">
-            {loadError
-              ? "Please try again later."
-              : "Check back soon — exercises are on the way."}
+            Check back soon — your teacher can add tutorials to the league.
           </p>
+        </div>
+      </div>
+    );
+  }
+
+  const showTutorial = (tutorialId) =>
+    setSearchParams({ tutorial: String(tutorialId) });
+  const showTutorialList = () => setSearchParams({});
+
+  // Multiple tutorials and none chosen (or a stale id not in this league):
+  // show the picker.
+  if (
+    !effectiveTutorialId ||
+    !tutorials.some((t) => t.id === effectiveTutorialId)
+  ) {
+    return (
+      <div className="min-h-screen pt-16 pb-12 bg-ui-lighter">
+        <div className="max-w-3xl mx-auto px-4">
+          <div className="bg-white rounded-lg shadow border border-ui-light/30 p-6">
+            <h1 className="text-2xl font-bold text-ui-dark">Tutorials</h1>
+            <p className="mt-2 text-ui-dark/70">
+              Pick a tutorial to work through its exercises.
+            </p>
+          </div>
+          <ul className="mt-6 space-y-3">
+            {tutorials.map((item) => (
+              <li key={item.id}>
+                <button
+                  onClick={() => showTutorial(item.id)}
+                  className="w-full flex items-center gap-4 bg-white rounded-lg shadow border border-ui-light/30 p-4 text-left transition-colors hover:border-primary/60 hover:bg-primary/5"
+                >
+                  <span className="flex-1 min-w-0">
+                    <span className="block font-medium text-ui-dark">
+                      {item.title}
+                    </span>
+                    {item.description && (
+                      <span className="block text-sm text-ui-dark/60 truncate">
+                        {item.description}
+                      </span>
+                    )}
+                    <span className="block text-sm text-ui-dark/50 mt-1">
+                      {item.exercise_count}{" "}
+                      {item.exercise_count === 1 ? "exercise" : "exercises"}
+                    </span>
+                  </span>
+                  <span className="text-ui-dark/40" aria-hidden="true">
+                    →
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    );
+  }
+
+  if (!tutorial) {
+    return (
+      <div className="min-h-screen pt-12 flex items-center justify-center bg-white">
+        <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-primary"></div>
+        <span className="ml-3 text-ui-dark">Loading tutorial...</span>
+      </div>
+    );
+  }
+
+  if (tutorial.exercises.length === 0) {
+    return (
+      <div className="min-h-screen pt-12 flex items-center justify-center bg-white">
+        <div className="text-center p-8 text-ui">
+          <p className="text-xl">This tutorial has no exercises yet.</p>
+          <p className="text-sm mt-2">
+            Check back soon — exercises are on the way.
+          </p>
+          {tutorials.length > 1 && (
+            <button
+              onClick={showTutorialList}
+              className="mt-4 py-2 px-4 rounded bg-ui-lighter text-ui-dark hover:bg-ui-light/50 transition-colors"
+            >
+              ← All tutorials
+            </button>
+          )}
         </div>
       </div>
     );
@@ -100,8 +210,11 @@ function Tutorial() {
   const selectedIndex = exercises.findIndex((e) => e.id === selectedExerciseId);
 
   const showExercise = (exerciseId) =>
-    setSearchParams({ exercise: String(exerciseId) });
-  const showOverview = () => setSearchParams({});
+    setSearchParams({
+      tutorial: String(tutorial.id),
+      exercise: String(exerciseId),
+    });
+  const showOverview = () => setSearchParams({ tutorial: String(tutorial.id) });
 
   if (selectedIndex === -1) {
     return (
@@ -109,6 +222,7 @@ function Tutorial() {
         tutorial={tutorial}
         progressByExerciseId={progressByExerciseId}
         onSelectExercise={showExercise}
+        onBackToList={tutorials.length > 1 ? showTutorialList : null}
       />
     );
   }

--- a/frontend/src/AgentGames/User/TutorialOverview.jsx
+++ b/frontend/src/AgentGames/User/TutorialOverview.jsx
@@ -4,9 +4,15 @@ import React from "react";
  * Landing view for the tutorial: title, description, overall progress, and
  * the exercises as an ordered list in teaching order. Each row shows the
  * team's status (completed / in progress / not started) and opens the
- * exercise workspace via onSelectExercise.
+ * exercise workspace via onSelectExercise. When the league has more than one
+ * tutorial, onBackToList renders a link back to the tutorial picker.
  */
-function TutorialOverview({ tutorial, progressByExerciseId, onSelectExercise }) {
+function TutorialOverview({
+  tutorial,
+  progressByExerciseId,
+  onSelectExercise,
+  onBackToList = null,
+}) {
   const exercises = tutorial.exercises;
   const passedCount = exercises.filter(
     (exercise) => progressByExerciseId[exercise.id]?.passed
@@ -18,6 +24,14 @@ function TutorialOverview({ tutorial, progressByExerciseId, onSelectExercise }) 
     <div className="min-h-screen pt-16 pb-12 bg-ui-lighter">
       <div className="max-w-3xl mx-auto px-4">
         <div className="bg-white rounded-lg shadow border border-ui-light/30 p-6">
+          {onBackToList && (
+            <button
+              onClick={onBackToList}
+              className="mb-3 py-1 px-3 text-sm rounded bg-ui-lighter text-ui-dark hover:bg-ui-light/50 transition-colors"
+            >
+              ← All tutorials
+            </button>
+          )}
           <h1 className="text-2xl font-bold text-ui-dark">{tutorial.title}</h1>
           {tutorial.description && (
             <p className="mt-2 text-ui-dark/70">{tutorial.description}</p>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,7 @@ import InstitutionLeague from "./AgentGames/Institution/InstitutionLeague";
 import InstitutionLeagueSimulation from "./AgentGames/Institution/InstitutionLeagueSimulation";
 import InstitutionLeagueSubmissions from "./AgentGames/Institution/InstitutionLeagueSubmissions";
 import InstitutionSubscription from "./AgentGames/Institution/InstitutionSubscription";
+import InstitutionProgress from "./AgentGames/Institution/InstitutionProgress";
 import Leaderboards from "./AgentGames/Leaderboards";
 import Admin from "./AgentGames/Admin/Admin";
 import AdminLeague from "./AgentGames/Admin/AdminLeague";
@@ -193,6 +194,14 @@ function App() {
             element={
               <AuthProtection requiredRole="institution" redirectTo="/Institution">
                 <InstitutionSubscription />
+              </AuthProtection>
+            }
+          />
+          <Route
+            path="InstitutionProgress"
+            element={
+              <AuthProtection requiredRole="institution" redirectTo="/Institution">
+                <InstitutionProgress />
               </AuthProtection>
             }
           />

--- a/frontend/src/Navbar.jsx
+++ b/frontend/src/Navbar.jsx
@@ -21,6 +21,7 @@ const NAV_LINKS_BY_ROLE = {
   ],
   institution: [
     { to: "/InstitutionTeam", label: "Team Section" },
+    { to: "/InstitutionProgress", label: "Team Progress" },
     { to: "/InstitutionLeague", label: "League Management" },
     { to: "/InstitutionLeagueSimulation", label: "League Simulation" },
     { to: "/InstitutionSubscription", label: "Subscription" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ addopts = "-v"
 omit = [
     "backend/scripts/*",
     "backend/rank_sim_tmp.py",
+    "backend/bench_validation.py",
     "backend/games/greedy_pig/test_threshold_calibration.py",
 ]
 


### PR DESCRIPTION
- League ↔ tutorial many-to-many: new LeagueTutorial table (with migration 2026-07-12_league_tutorials.sql) turns tutorials into a global content library that institutions attach to leagues via new get/update endpoints; teams now only see the tutorials attached to their league, while admins/institutions still browse the full library.
- Tutorial attachment UI: LeagueTutorialSelector / LeagueTutorials components plus a reworked LeagueCreation flow let institutions pick tutorials when creating or editing a league, backed by new useLeagueAPI hooks.
- Team progress visibility for institutions: new team_progress endpoint aggregates per-team submission/tutorial completion stats across an institution's leagues, rendered in a new InstitutionProgress page (completion bars, last-activity timestamps) linked from the navbar.
- Per-game validation simulation counts: replaced the VALIDATION_SIMULATIONS config dict and the num_simulations task parameter with a validation_simulations class attribute on each game, benchmarked per game (e.g. greedy_pig 300, hearts 2) so every validation load stays under one second; added bench_validation.py to measure it.
- Tests: new integration suites for league tutorials (251 lines) and team progress (259 lines), plus expanded tutorial-router tests covering the new role-based scoping.