### PR TITLE
Exercise file

### DIFF
--- a/backend/database/db_models.py
+++ b/backend/database/db_models.py
@@ -393,10 +393,13 @@ class LeagueTutorial(SQLModel, table=True):
 class Exercise(SQLModel, table=True):
     """One coding problem inside a tutorial.
 
-    Test cases are function I/O pairs: the student's code must define
-    `entry_function`, and each test case in `test_cases` is
-    {"name": str, "args": [...], "expected": ...}. The exercise worker calls
-    the function with `args` and compares the return value to `expected`.
+    Tests live in `test_code`: an admin-trusted Python test script
+    (backend/tasks/exercise_test_code.py) exec'd into the same namespace as
+    the student's code. It can test multiple functions and check print
+    output. Seed-managed only: the admin CRUD endpoints neither expose nor
+    overwrite it. `entry_function` still names the one function every
+    submission must define, so a wrong-name submission fails fast with a
+    clear message.
     """
 
     id: Optional[int] = Field(default=None, primary_key=True)
@@ -406,7 +409,9 @@ class Exercise(SQLModel, table=True):
     problem_markdown: str = Field(sa_column=Column(Text(), nullable=False))
     starter_code: str = Field(default="", sa_column=Column(Text(), nullable=False))
     entry_function: str
-    test_cases: list = Field(sa_column=Column(JSON, nullable=False))
+    test_code: Optional[str] = Field(
+        default=None, sa_column=Column(Text(), nullable=True)
+    )
     created_at: datetime = Field(
         default_factory=utc_now, sa_column=Column(DateTime(timezone=True))
     )

--- a/backend/database/db_models.py
+++ b/backend/database/db_models.py
@@ -399,7 +399,9 @@ class Exercise(SQLModel, table=True):
     output. Authored by the seed script or through the admin exercise
     editor; students never see it. `entry_function` still names the one
     function every submission must define, so a wrong-name submission fails
-    fast with a clear message.
+    fast with a clear message. `solution` is an optional reference solution
+    for the admin editor's Run workflow — like test_code, it never reaches
+    students.
     """
 
     id: Optional[int] = Field(default=None, primary_key=True)
@@ -410,6 +412,9 @@ class Exercise(SQLModel, table=True):
     starter_code: str = Field(default="", sa_column=Column(Text(), nullable=False))
     entry_function: str
     test_code: Optional[str] = Field(
+        default=None, sa_column=Column(Text(), nullable=True)
+    )
+    solution: Optional[str] = Field(
         default=None, sa_column=Column(Text(), nullable=True)
     )
     created_at: datetime = Field(

--- a/backend/database/db_models.py
+++ b/backend/database/db_models.py
@@ -396,10 +396,10 @@ class Exercise(SQLModel, table=True):
     Tests live in `test_code`: an admin-trusted Python test script
     (backend/tasks/exercise_test_code.py) exec'd into the same namespace as
     the student's code. It can test multiple functions and check print
-    output. Seed-managed only: the admin CRUD endpoints neither expose nor
-    overwrite it. `entry_function` still names the one function every
-    submission must define, so a wrong-name submission fails fast with a
-    clear message.
+    output. Authored by the seed script or through the admin exercise
+    editor; students never see it. `entry_function` still names the one
+    function every submission must define, so a wrong-name submission fails
+    fast with a clear message.
     """
 
     id: Optional[int] = Field(default=None, primary_key=True)

--- a/backend/migrations/2026-07-13_exercise_solution.sql
+++ b/backend/migrations/2026-07-13_exercise_solution.sql
@@ -1,0 +1,4 @@
+-- Optional reference solution per exercise, used by the admin exercise
+-- editor to verify the test script against a known-good implementation.
+-- Never exposed to students.
+ALTER TABLE exercise ADD COLUMN IF NOT EXISTS solution TEXT;

--- a/backend/migrations/2026-07-13_exercise_test_code.sql
+++ b/backend/migrations/2026-07-13_exercise_test_code.sql
@@ -1,0 +1,5 @@
+-- Exercises are now tested by an admin-trusted Python test script
+-- (see backend/tasks/exercise_test_code.py); the declarative JSON
+-- test_cases column is obsolete and dropped without back-compat.
+ALTER TABLE exercise ADD COLUMN IF NOT EXISTS test_code TEXT;
+ALTER TABLE exercise DROP COLUMN IF EXISTS test_cases;

--- a/backend/routes/demo/demo_db.py
+++ b/backend/routes/demo/demo_db.py
@@ -2,7 +2,7 @@ import logging
 import secrets
 import string
 from datetime import timedelta
-from typing import List, Tuple
+from typing import List
 
 from sqlmodel import Session, delete, select
 
@@ -64,9 +64,7 @@ def generate_demo_password(length=12):
     return "".join(secrets.choice(alphabet) for _ in range(length))
 
 
-def create_demo_user(
-    session: Session, username: str, email: str = None
-) -> Tuple[Team, str]:
+def create_demo_user(session: Session, username: str, email: str = None) -> Team:
     """Create a temporary demo user"""
     # Save user info to DemoUser table
     save_demo_user_info(session, username, email)

--- a/backend/routes/tutorial/tutorial_db.py
+++ b/backend/routes/tutorial/tutorial_db.py
@@ -302,10 +302,8 @@ def get_latest_exercise_submission(
 
 
 # ---------------------------------------------------------------------------
-# Admin CRUD. Students never see entry_function; the admin detail view below
-# is the only read path that returns it. test_code is seed-managed and stays
-# out of the admin surface entirely — these helpers neither return nor
-# overwrite it.
+# Admin CRUD. Students never see entry_function/test_code; the admin detail
+# view below is the only read path that returns them.
 # ---------------------------------------------------------------------------
 
 
@@ -325,6 +323,7 @@ def _exercise_admin_dict(exercise: Exercise) -> dict:
         "problem_markdown": exercise.problem_markdown,
         "starter_code": exercise.starter_code,
         "entry_function": exercise.entry_function,
+        "test_code": exercise.test_code,
     }
 
 
@@ -484,12 +483,12 @@ def create_exercise(
     problem_markdown: str,
     starter_code: str,
     entry_function: str,
+    test_code: Optional[str],
 ) -> dict:
     """Append a new exercise at the end of the tutorial.
 
-    Created without a test script (test_code is seed-managed); submitting
-    against it errors with "This exercise defines no tests" until one is
-    seeded.
+    An exercise created without a test script (test_code=None) errors with
+    "This exercise defines no tests" on submission until one is saved.
     """
     tutorial = _get_tutorial_or_raise(session, tutorial_id)
     next_index = max(
@@ -502,6 +501,7 @@ def create_exercise(
         problem_markdown=problem_markdown,
         starter_code=starter_code,
         entry_function=entry_function,
+        test_code=test_code,
     )
     session.add(exercise)
     session.commit()
@@ -516,14 +516,14 @@ def update_exercise(
     problem_markdown: str,
     starter_code: str,
     entry_function: str,
+    test_code: Optional[str],
 ) -> dict:
-    # Deliberately never touches test_code: editing a seeded exercise's
-    # title/markdown through the admin UI preserves its test script.
     exercise = get_exercise_by_id(session, exercise_id)
     exercise.title = title
     exercise.problem_markdown = problem_markdown
     exercise.starter_code = starter_code
     exercise.entry_function = entry_function
+    exercise.test_code = test_code
     session.commit()
     session.refresh(exercise)
     return _exercise_admin_dict(exercise)

--- a/backend/routes/tutorial/tutorial_db.py
+++ b/backend/routes/tutorial/tutorial_db.py
@@ -302,8 +302,10 @@ def get_latest_exercise_submission(
 
 
 # ---------------------------------------------------------------------------
-# Admin CRUD. Students never see entry_function/test_cases; the admin detail
-# view below is the only read path that returns them.
+# Admin CRUD. Students never see entry_function; the admin detail view below
+# is the only read path that returns it. test_code is seed-managed and stays
+# out of the admin surface entirely — these helpers neither return nor
+# overwrite it.
 # ---------------------------------------------------------------------------
 
 
@@ -323,7 +325,6 @@ def _exercise_admin_dict(exercise: Exercise) -> dict:
         "problem_markdown": exercise.problem_markdown,
         "starter_code": exercise.starter_code,
         "entry_function": exercise.entry_function,
-        "test_cases": exercise.test_cases,
     }
 
 
@@ -483,9 +484,13 @@ def create_exercise(
     problem_markdown: str,
     starter_code: str,
     entry_function: str,
-    test_cases: list,
 ) -> dict:
-    """Append a new exercise at the end of the tutorial."""
+    """Append a new exercise at the end of the tutorial.
+
+    Created without a test script (test_code is seed-managed); submitting
+    against it errors with "This exercise defines no tests" until one is
+    seeded.
+    """
     tutorial = _get_tutorial_or_raise(session, tutorial_id)
     next_index = max(
         (exercise.order_index for exercise in tutorial.exercises), default=-1
@@ -497,7 +502,6 @@ def create_exercise(
         problem_markdown=problem_markdown,
         starter_code=starter_code,
         entry_function=entry_function,
-        test_cases=test_cases,
     )
     session.add(exercise)
     session.commit()
@@ -512,14 +516,14 @@ def update_exercise(
     problem_markdown: str,
     starter_code: str,
     entry_function: str,
-    test_cases: list,
 ) -> dict:
+    # Deliberately never touches test_code: editing a seeded exercise's
+    # title/markdown through the admin UI preserves its test script.
     exercise = get_exercise_by_id(session, exercise_id)
     exercise.title = title
     exercise.problem_markdown = problem_markdown
     exercise.starter_code = starter_code
     exercise.entry_function = entry_function
-    exercise.test_cases = test_cases
     session.commit()
     session.refresh(exercise)
     return _exercise_admin_dict(exercise)

--- a/backend/routes/tutorial/tutorial_db.py
+++ b/backend/routes/tutorial/tutorial_db.py
@@ -324,6 +324,7 @@ def _exercise_admin_dict(exercise: Exercise) -> dict:
         "starter_code": exercise.starter_code,
         "entry_function": exercise.entry_function,
         "test_code": exercise.test_code,
+        "solution": exercise.solution,
     }
 
 
@@ -484,6 +485,7 @@ def create_exercise(
     starter_code: str,
     entry_function: str,
     test_code: Optional[str],
+    solution: Optional[str],
 ) -> dict:
     """Append a new exercise at the end of the tutorial.
 
@@ -502,6 +504,7 @@ def create_exercise(
         starter_code=starter_code,
         entry_function=entry_function,
         test_code=test_code,
+        solution=solution,
     )
     session.add(exercise)
     session.commit()
@@ -517,6 +520,7 @@ def update_exercise(
     starter_code: str,
     entry_function: str,
     test_code: Optional[str],
+    solution: Optional[str],
 ) -> dict:
     exercise = get_exercise_by_id(session, exercise_id)
     exercise.title = title
@@ -524,6 +528,7 @@ def update_exercise(
     exercise.starter_code = starter_code
     exercise.entry_function = entry_function
     exercise.test_code = test_code
+    exercise.solution = solution
     session.commit()
     session.refresh(exercise)
     return _exercise_admin_dict(exercise)

--- a/backend/routes/tutorial/tutorial_models.py
+++ b/backend/routes/tutorial/tutorial_models.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from pydantic import BaseModel, field_validator
 
@@ -35,17 +35,26 @@ class TutorialUpdateRequest(BaseModel):
 
 
 class ExerciseRequest(BaseModel):
-    """Exercise definition, used for both create and update (PUT).
+    """Full exercise definition, used for both create and update (PUT).
 
-    Deliberately excludes `test_code`: the test script is seed-managed, so an
-    admin editing title/markdown through this model can neither see nor
-    clobber it.
+    `test_code` is the exercise's Python test script
+    (backend/tasks/exercise_test_code.py). A blank script is stored as NULL
+    so submitting against it hits the worker's loud "defines no tests" error
+    instead of passing vacuously.
     """
 
     title: str
     problem_markdown: str
     starter_code: str = ""
     entry_function: str
+    test_code: Optional[str] = None
+
+    @field_validator("test_code")
+    @classmethod
+    def blank_test_code_is_none(cls, value: Optional[str]) -> Optional[str]:
+        if value is not None and not value.strip():
+            return None
+        return value
 
     @field_validator("title")
     @classmethod
@@ -63,6 +72,16 @@ class ExerciseRequest(BaseModel):
                 "Entry function must be a valid Python function name"
             )
         return value
+
+
+class ExerciseRunRequest(BaseModel):
+    """Admin dry run: execute a test script against code without touching the
+    DB. Stateless (no exercise id) so an exercise can be tested before it is
+    ever saved."""
+
+    code: str
+    entry_function: str
+    test_code: Optional[str] = None
 
 
 class ExerciseReorderRequest(BaseModel):

--- a/backend/routes/tutorial/tutorial_models.py
+++ b/backend/routes/tutorial/tutorial_models.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import List
 
 from pydantic import BaseModel, field_validator
 
@@ -8,22 +8,6 @@ class ExerciseSubmissionRequest(BaseModel):
 
     exercise_id: int
     code: str
-
-
-class TestCase(BaseModel):
-    """One function I/O pair: the worker calls the entry function with `args`
-    and compares the return value to `expected` with ==."""
-
-    name: str
-    args: List[Any]
-    expected: Any
-
-    @field_validator("name")
-    @classmethod
-    def name_not_blank(cls, value: str) -> str:
-        if not value.strip():
-            raise ValueError("Test case name cannot be empty")
-        return value
 
 
 class TutorialCreateRequest(BaseModel):
@@ -51,13 +35,17 @@ class TutorialUpdateRequest(BaseModel):
 
 
 class ExerciseRequest(BaseModel):
-    """Full exercise definition, used for both create and update (PUT)."""
+    """Exercise definition, used for both create and update (PUT).
+
+    Deliberately excludes `test_code`: the test script is seed-managed, so an
+    admin editing title/markdown through this model can neither see nor
+    clobber it.
+    """
 
     title: str
     problem_markdown: str
     starter_code: str = ""
     entry_function: str
-    test_cases: List[TestCase]
 
     @field_validator("title")
     @classmethod
@@ -74,13 +62,6 @@ class ExerciseRequest(BaseModel):
             raise ValueError(
                 "Entry function must be a valid Python function name"
             )
-        return value
-
-    @field_validator("test_cases")
-    @classmethod
-    def at_least_one_test_case(cls, value: List[TestCase]) -> List[TestCase]:
-        if not value:
-            raise ValueError("An exercise needs at least one test case")
         return value
 
 

--- a/backend/routes/tutorial/tutorial_models.py
+++ b/backend/routes/tutorial/tutorial_models.py
@@ -38,9 +38,10 @@ class ExerciseRequest(BaseModel):
     """Full exercise definition, used for both create and update (PUT).
 
     `test_code` is the exercise's Python test script
-    (backend/tasks/exercise_test_code.py). A blank script is stored as NULL
-    so submitting against it hits the worker's loud "defines no tests" error
-    instead of passing vacuously.
+    (backend/tasks/exercise_test_code.py); `solution` is an optional
+    reference solution for the admin editor. Both are stored as NULL when
+    blank — for test_code so submitting hits the worker's loud "defines no
+    tests" error instead of passing vacuously.
     """
 
     title: str
@@ -48,10 +49,11 @@ class ExerciseRequest(BaseModel):
     starter_code: str = ""
     entry_function: str
     test_code: Optional[str] = None
+    solution: Optional[str] = None
 
-    @field_validator("test_code")
+    @field_validator("test_code", "solution")
     @classmethod
-    def blank_test_code_is_none(cls, value: Optional[str]) -> Optional[str]:
+    def blank_is_none(cls, value: Optional[str]) -> Optional[str]:
         if value is not None and not value.strip():
             return None
         return value

--- a/backend/routes/tutorial/tutorial_router.py
+++ b/backend/routes/tutorial/tutorial_router.py
@@ -34,8 +34,9 @@ from backend.routes.tutorial.tutorial_db import (
     update_tutorial,
 )
 from backend.routes.tutorial.tutorial_models import (
-    ExerciseRequest,
     ExerciseReorderRequest,
+    ExerciseRequest,
+    ExerciseRunRequest,
     ExerciseSubmissionRequest,
     TutorialCreateRequest,
     TutorialUpdateRequest,
@@ -203,8 +204,8 @@ async def get_tutorial_progress_endpoint(
 
 # ---------------------------------------------------------------------------
 # Admin content management. The admin detail endpoint is the only read path
-# exposing entry_function — the student endpoints above keep it server-side.
-# test_code is seed-managed and not exposed here at all.
+# exposing entry_function/test_code — the student endpoints above keep them
+# server-side.
 # ---------------------------------------------------------------------------
 
 
@@ -217,6 +218,40 @@ async def get_tutorial_admin_endpoint(
 ):
     """One tutorial with full exercise definitions, including test cases."""
     return get_tutorial_admin_detail(session, tutorial_id)
+
+
+@tutorial_router.post("/admin/run-exercise")
+@verify_admin_role
+async def run_exercise_endpoint(
+    run: ExerciseRunRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """Dry-run a test script against code without saving anything.
+
+    Backs the admin exercise editor's Run button. Unlike /submit-exercise,
+    every outcome is a 200 with the full run result — including `traceback`
+    when the test script itself fails to exec, since the caller is the person
+    debugging that script. The code goes through the same AST safety check as
+    student submissions so an admin learns here, not from students, that
+    their starter/solution code trips the allowlist.
+    """
+    is_safe, error_message = validate_code(run.code)
+    if not is_safe:
+        return {
+            "status": "error",
+            "message": f"Code is not safe: {error_message}",
+            "passed": False,
+            "test_results": [],
+            "duration_ms": None,
+            "traceback": None,
+            "stdout": None,
+        }
+    async_result = enqueue_exercise_run(
+        code=run.code,
+        entry_function=run.entry_function,
+        test_code=run.test_code,
+    )
+    return await await_exercise_result(async_result)
 
 
 @tutorial_router.post("/tutorials")
@@ -272,6 +307,7 @@ async def create_exercise_endpoint(
         problem_markdown=exercise.problem_markdown,
         starter_code=exercise.starter_code,
         entry_function=exercise.entry_function,
+        test_code=exercise.test_code,
     )
 
 
@@ -283,7 +319,7 @@ async def update_exercise_endpoint(
     current_user: dict = Depends(get_current_user),
     session: Session = Depends(get_db),
 ):
-    """Replace an exercise's definition (test_code stays seed-managed)."""
+    """Replace an exercise's definition (all fields, tests included)."""
     return update_exercise(
         session,
         exercise_id,
@@ -291,6 +327,7 @@ async def update_exercise_endpoint(
         problem_markdown=exercise.problem_markdown,
         starter_code=exercise.starter_code,
         entry_function=exercise.entry_function,
+        test_code=exercise.test_code,
     )
 
 

--- a/backend/routes/tutorial/tutorial_router.py
+++ b/backend/routes/tutorial/tutorial_router.py
@@ -102,7 +102,7 @@ async def submit_exercise(
         async_result = enqueue_exercise_run(
             code=submission.code,
             entry_function=exercise.entry_function,
-            test_cases=exercise.test_cases,
+            test_code=exercise.test_code,
         )
         run_result = await await_exercise_result(async_result)
 
@@ -203,8 +203,8 @@ async def get_tutorial_progress_endpoint(
 
 # ---------------------------------------------------------------------------
 # Admin content management. The admin detail endpoint is the only read path
-# exposing entry_function/test_cases — the student endpoints above keep them
-# server-side.
+# exposing entry_function — the student endpoints above keep it server-side.
+# test_code is seed-managed and not exposed here at all.
 # ---------------------------------------------------------------------------
 
 
@@ -272,7 +272,6 @@ async def create_exercise_endpoint(
         problem_markdown=exercise.problem_markdown,
         starter_code=exercise.starter_code,
         entry_function=exercise.entry_function,
-        test_cases=[case.model_dump() for case in exercise.test_cases],
     )
 
 
@@ -284,7 +283,7 @@ async def update_exercise_endpoint(
     current_user: dict = Depends(get_current_user),
     session: Session = Depends(get_db),
 ):
-    """Replace an exercise's definition (all fields)."""
+    """Replace an exercise's definition (test_code stays seed-managed)."""
     return update_exercise(
         session,
         exercise_id,
@@ -292,7 +291,6 @@ async def update_exercise_endpoint(
         problem_markdown=exercise.problem_markdown,
         starter_code=exercise.starter_code,
         entry_function=exercise.entry_function,
-        test_cases=[case.model_dump() for case in exercise.test_cases],
     )
 
 

--- a/backend/routes/tutorial/tutorial_router.py
+++ b/backend/routes/tutorial/tutorial_router.py
@@ -308,6 +308,7 @@ async def create_exercise_endpoint(
         starter_code=exercise.starter_code,
         entry_function=exercise.entry_function,
         test_code=exercise.test_code,
+        solution=exercise.solution,
     )
 
 
@@ -328,6 +329,7 @@ async def update_exercise_endpoint(
         starter_code=exercise.starter_code,
         entry_function=exercise.entry_function,
         test_code=exercise.test_code,
+        solution=exercise.solution,
     )
 
 

--- a/backend/scripts/seed_tutorial.py
+++ b/backend/scripts/seed_tutorial.py
@@ -1,8 +1,14 @@
-"""Seed THE tutorial: 10 exercises building up to a Greedy Pig agent.
+"""Seed THE tutorial: 5 exercises building up to a Greedy Pig agent.
 
-The progression starts at basic dictionary lookups and rounding, and ends
-with parsing the real nested `game_state` dictionary that Greedy Pig passes
-to `make_decision`.
+The progression starts at basic dictionary lookups and rounding, then covers
+printing output and splitting logic across helper functions — the shape of a
+real agent's decision code.
+
+Every exercise's tests are a Python test script (`Exercise.test_code`) run by
+backend/tasks/exercise_test_code.py: `test_*` functions calling the student's
+functions by name, recording results with the injected `check`,
+`check_output`, and `capture` helpers. The scripts are admin-trusted and
+seed-managed — students never see or touch them.
 
 Idempotent overwrite: the platform has exactly one tutorial, so this script
 reuses the oldest Tutorial row (deleting any others), overwrites its title
@@ -42,19 +48,19 @@ logger = logging.getLogger(__name__)
 
 TUTORIAL_TITLE = "Python Foundations for Greedy Pig"
 TUTORIAL_DESCRIPTION = (
-    "Ten short exercises that build every Python skill you need to write a "
+    "Five short exercises that build every Python skill you need to write a "
     "winning Greedy Pig agent. You start with simple dictionary lookups and "
-    "rounding, and finish by parsing the real nested game_state dictionary "
-    "and making a banking decision from it. Each exercise gives you a "
-    "problem, starter code, and test cases — submit your code to see which "
-    "tests pass."
+    "rounding, then learn to print a scoreboard and to split a decision "
+    "across helper functions — exactly how a real agent is built. Each "
+    "exercise gives you a problem, starter code, and tests — submit your "
+    "code to see which tests pass."
 )
 
 
 # ---------------------------------------------------------------------------
-# Exercise definitions, in teaching order. Each test case is
-# {"name": str, "args": [...], "expected": ...}; the exercise worker calls
-# the entry function with `args` and compares the return value with ==.
+# Exercise definitions, in teaching order. Each spec's `test_code` is a
+# trusted Python test script exec'd into the same namespace as the student's
+# code; see backend/tasks/exercise_test_code.py for the helper API.
 # ---------------------------------------------------------------------------
 
 EXERCISES = [
@@ -103,28 +109,26 @@ def get_banked(banked_money, name):
     # If `name` is not in the dictionary, return 0.
     pass  # Replace this line with your code
 """,
-        "test_cases": [
-            {
-                "name": "reads Alice's money",
-                "args": [{"Alice": 30, "Bob": 55}, "Alice"],
-                "expected": 30,
-            },
-            {
-                "name": "reads Bob's money",
-                "args": [{"Alice": 30, "Bob": 55}, "Bob"],
-                "expected": 55,
-            },
-            {
-                "name": "missing player returns 0",
-                "args": [{"Alice": 30}, "Zoe"],
-                "expected": 0,
-            },
-            {
-                "name": "empty scoreboard returns 0",
-                "args": [{}, "Alice"],
-                "expected": 0,
-            },
-        ],
+        "test_code": """\
+def test_reads_alice():
+    \"\"\"reads Alice's money\"\"\"
+    check(get_banked({"Alice": 30, "Bob": 55}, "Alice"), 30)
+
+
+def test_reads_bob():
+    \"\"\"reads Bob's money\"\"\"
+    check(get_banked({"Alice": 30, "Bob": 55}, "Bob"), 55)
+
+
+def test_missing_player():
+    \"\"\"missing player returns 0\"\"\"
+    check(get_banked({"Alice": 30}, "Zoe"), 0)
+
+
+def test_empty_scoreboard():
+    \"\"\"empty scoreboard returns 0\"\"\"
+    check(get_banked({}, "Alice"), 0)
+""",
     },
     # 2 ------------------------------------------------------------------
     {
@@ -167,33 +171,31 @@ def split_reward(pool, num_players):
     # then round one share to 2 decimal places.
     pass  # Replace this line with your code
 """,
-        "test_cases": [
-            {
-                "name": "two players split 10",
-                "args": [10, 2],
-                "expected": 5.0,
-            },
-            {
-                "name": "three players split 10",
-                "args": [10, 3],
-                "expected": 3.33,
-            },
-            {
-                "name": "one player keeps it all",
-                "args": [10, 1],
-                "expected": 10.0,
-            },
-            {
-                "name": "two players split 7",
-                "args": [7, 2],
-                "expected": 3.5,
-            },
-            {
-                "name": "three players split 20",
-                "args": [20, 3],
-                "expected": 6.67,
-            },
-        ],
+        "test_code": """\
+def test_two_players_split_10():
+    \"\"\"two players split 10\"\"\"
+    check(split_reward(10, 2), 5.0)
+
+
+def test_three_players_split_10():
+    \"\"\"three players split 10\"\"\"
+    check(split_reward(10, 3), 3.33)
+
+
+def test_one_player_keeps_it_all():
+    \"\"\"one player keeps it all\"\"\"
+    check(split_reward(10, 1), 10.0)
+
+
+def test_two_players_split_7():
+    \"\"\"two players split 7\"\"\"
+    check(split_reward(7, 2), 3.5)
+
+
+def test_three_players_split_20():
+    \"\"\"three players split 20\"\"\"
+    check(split_reward(20, 3), 6.67)
+""",
     },
     # 3 ------------------------------------------------------------------
     {
@@ -242,645 +244,204 @@ def should_bank(unbanked, threshold):
     # otherwise return "continue".
     pass  # Replace this line with your code
 """,
-        "test_cases": [
-            {
-                "name": "well over the threshold banks",
-                "args": [25, 20],
-                "expected": "bank",
-            },
-            {
-                "name": "under the threshold continues",
-                "args": [12, 20],
-                "expected": "continue",
-            },
-            {
-                "name": "exactly on the threshold banks",
-                "args": [20, 20],
-                "expected": "bank",
-            },
-            {
-                "name": "nothing unbanked continues",
-                "args": [0, 15],
-                "expected": "continue",
-            },
-        ],
+        "test_code": """\
+def test_over_threshold():
+    \"\"\"well over the threshold banks\"\"\"
+    check(should_bank(25, 20), "bank")
+
+
+def test_under_threshold():
+    \"\"\"under the threshold continues\"\"\"
+    check(should_bank(12, 20), "continue")
+
+
+def test_exactly_on_threshold():
+    \"\"\"exactly on the threshold banks\"\"\"
+    check(should_bank(20, 20), "bank")
+
+
+def test_nothing_unbanked():
+    \"\"\"nothing unbanked continues\"\"\"
+    check(should_bank(0, 15), "continue")
+""",
     },
     # 4 ------------------------------------------------------------------
     {
-        "title": "My Total Money",
-        "entry_function": "total_money",
+        "title": "Announce the Scores",
+        "entry_function": "print_scoreboard",
         "problem_markdown": """\
-# My Total Money
+# Announce the Scores
 
-Greedy Pig keeps your money in **two** dictionaries: `banked_money`
-(safe, counts toward winning) and `unbanked_money` (at risk — one bad
-roll and it's gone). To know how rich a player really is right now, you
-add their entry from each dictionary together.
+So far your functions have **returned** values. This one is different: it
+**prints**. After every round, Greedy Pig announces the scoreboard — and
+printing is also how you'll debug your own agent, so it's worth getting
+right.
 
 ## The Task
 
-Write a function `total_money(banked_money, unbanked_money, name)` that
-returns the player's banked money plus their unbanked money.
+Write a function `print_scoreboard(banked_money)` that prints one line
+per player, in the dictionary's order, in exactly this format:
 
-Both dictionaries always contain `name`.
+```
+name: amount
+```
+
+The function should print — not return — the lines. It should return
+nothing.
 
 ## Examples
 
 ```python
-total_money({"Alice": 40, "Bob": 10}, {"Alice": 7, "Bob": 0}, "Alice")
-# 47
+print_scoreboard({"Alice": 30, "Bob": 55})
+# prints:
+# Alice: 30
+# Bob: 55
 
-total_money({"Alice": 40, "Bob": 10}, {"Alice": 7, "Bob": 0}, "Bob")
-# 10
+print_scoreboard({"Cara": 12})
+# prints:
+# Cara: 12
 ```
 
 ## Hints
 
-- Look `name` up in each dictionary separately, then add the two numbers.
+- Loop over the players: `for name in banked_money:` — or over
+  `banked_money.items()` to get name and amount together.
+- An f-string builds the line: `f"{name}: {amount}"`.
+- `print(...)` each line — don't collect them into a string and return it.
 """,
         "starter_code": """\
-def total_money(banked_money, unbanked_money, name):
-    # Add the player's banked money and unbanked money together.
+def print_scoreboard(banked_money):
+    # Print one line per player, like
+    #   Alice: 30
+    # in the dictionary's order. Print, don't return!
     pass  # Replace this line with your code
 """,
-        "test_cases": [
-            {
-                "name": "banked plus unbanked",
-                "args": [{"Alice": 40, "Bob": 10}, {"Alice": 7, "Bob": 0}, "Alice"],
-                "expected": 47,
-            },
-            {
-                "name": "zero unbanked adds nothing",
-                "args": [{"Alice": 40, "Bob": 10}, {"Alice": 7, "Bob": 0}, "Bob"],
-                "expected": 10,
-            },
-            {
-                "name": "all money still unbanked",
-                "args": [{"Cara": 0}, {"Cara": 22}, "Cara"],
-                "expected": 22,
-            },
-            {
-                "name": "flat broke",
-                "args": [{"Dana": 0}, {"Dana": 0}, "Dana"],
-                "expected": 0,
-            },
-        ],
+        "test_code": """\
+def test_two_players():
+    \"\"\"prints one line per player, in order\"\"\"
+    with capture() as out:
+        print_scoreboard({"Alice": 30, "Bob": 55})
+    check_output(out.text, "Alice: 30\\nBob: 55")
+
+
+def test_single_player():
+    \"\"\"a single player prints a single line\"\"\"
+    with capture() as out:
+        print_scoreboard({"Cara": 12})
+    check_output(out.text, "Cara: 12")
+
+
+def test_empty_scoreboard():
+    \"\"\"an empty scoreboard prints nothing\"\"\"
+    with capture() as out:
+        print_scoreboard({})
+    check_output(out.text, "")
+
+
+def test_prints_not_returns():
+    \"\"\"the function prints instead of returning\"\"\"
+    with capture() as out:
+        result = print_scoreboard({"Alice": 30})
+    check(result, None, name="returns None (print, don't return)")
+""",
     },
     # 5 ------------------------------------------------------------------
     {
-        "title": "Money on the Table",
-        "entry_function": "pot_size",
+        "title": "Safe to Roll?",
+        "entry_function": "decide",
         "problem_markdown": """\
-# Money on the Table
+# Safe to Roll?
 
-Sometimes an agent cares about the whole table, not just itself. How much
-unbanked money is at risk right now across **all** players? If the next
-roll is a 1, all of it vanishes.
+Real agents don't cram everything into one function — they split their
+thinking into **helpers**. Here you write two functions, and the second
+one calls the first.
 
 ## The Task
 
-Write a function `pot_size(unbanked_money)` that returns the sum of every
-value in the dictionary. An empty dictionary means nothing is at risk, so
-return `0`.
+Write **both** of these functions:
+
+1. `is_safe(unbanked)` — returns `True` if `unbanked` is less than `20`,
+   otherwise `False`. (At 20 or more, one bad roll loses too much.)
+
+2. `decide(unbanked, banked)` — applies these rules **in order** and
+   returns the first one that fires:
+   1. If banking now would reach 100 or more in total
+      (`banked + unbanked >= 100`) → return `"bank"` — that wins the game!
+   2. If `is_safe(unbanked)` says it's safe → return `"continue"`.
+   3. Otherwise → return `"bank"`.
+
+`decide` must **call** `is_safe` — the tests check both functions, and
+they check that `decide` agrees with your `is_safe`.
 
 ## Examples
 
 ```python
-pot_size({"Alice": 5, "Bob": 12, "Cara": 0})
-# 17
+is_safe(5)
+# True
 
-pot_size({})
-# 0
+is_safe(20)
+# False
+
+decide(5, 10)
+# "continue"   (safe pile, nowhere near 100)
+
+decide(25, 10)
+# "bank"       (25 unbanked is not safe)
+
+decide(10, 95)
+# "bank"       (95 + 10 = 105 — banking now wins)
 ```
 
 ## Hints
 
-- `unbanked_money.values()` gives you just the amounts, without the names.
-- You can loop over them and add to a running total —
-  or look up what Python's built-in `sum()` does.
+- `unbanked < 20` is already a True/False value — you can return it
+  directly.
+- In `decide`, check the winning rule first, then use
+  `if is_safe(unbanked):` for the second rule.
 """,
         "starter_code": """\
-def pot_size(unbanked_money):
-    # Add up every amount in the dictionary and return the total.
+def is_safe(unbanked):
+    # True if the unbanked pile is still small enough to risk (< 20).
+    pass  # Replace this line with your code
+
+
+def decide(unbanked, banked):
+    # Rule 1: banking now wins (banked + unbanked >= 100) -> "bank"
+    # Rule 2: still safe to roll (use is_safe!)          -> "continue"
+    # Rule 3: otherwise                                   -> "bank"
     pass  # Replace this line with your code
 """,
-        "test_cases": [
-            {
-                "name": "adds three players' piles",
-                "args": [{"Alice": 5, "Bob": 12, "Cara": 0}],
-                "expected": 17,
-            },
-            {
-                "name": "single player",
-                "args": [{"Alice": 31}],
-                "expected": 31,
-            },
-            {
-                "name": "empty table is 0",
-                "args": [{}],
-                "expected": 0,
-            },
-            {
-                "name": "everyone just banked",
-                "args": [{"Alice": 0, "Bob": 0}],
-                "expected": 0,
-            },
-        ],
-    },
-    # 6 ------------------------------------------------------------------
-    {
-        "title": "Find the Leader",
-        "entry_function": "find_leader",
-        "problem_markdown": """\
-# Find the Leader
+        "test_code": """\
+def test_is_safe_small_piles():
+    \"\"\"is_safe: a small pile is safe\"\"\"
+    check(is_safe(5), True, name="is_safe(5) is True")
+    check(is_safe(19), True, name="is_safe(19) is True")
 
-Good agents play differently when they are winning than when they are
-chasing. Step one of that: work out **who** is in front. Here you find the
-name of the player with the most banked money.
 
-## The Task
+def test_is_safe_big_piles():
+    \"\"\"is_safe: 20 or more is not safe\"\"\"
+    check(is_safe(20), False, name="is_safe(20) is False")
+    check(is_safe(35), False, name="is_safe(35) is False")
 
-Write a function `find_leader(banked_money)` that returns the **name**
-(the key, not the amount) of the player with the highest banked money.
 
-The dictionary is never empty, and in every test exactly one player is in
-the lead — you don't need to handle ties.
+def test_decide_rules():
+    \"\"\"decide applies the three rules in order\"\"\"
+    check(decide(5, 10), "continue", name='decide(5, 10) is "continue"')
+    check(decide(25, 10), "bank", name='decide(25, 10) is "bank"')
+    check(decide(10, 95), "bank", name='decide(10, 95) wins the game')
+    check(decide(19, 50), "continue", name='decide(19, 50) is "continue"')
 
-## Examples
 
-```python
-find_leader({"Alice": 30, "Bob": 55, "Cara": 41})
-# "Bob"
-
-find_leader({"Alice": 90})
-# "Alice"
-```
-
-## Hints
-
-- `for name in banked_money:` loops over the names;
-  `banked_money[name]` gives each one's amount.
-- Keep two variables while you loop: the best name so far and the best
-  amount so far. Update both whenever you see a bigger amount.
+def test_decide_agrees_with_is_safe():
+    \"\"\"decide follows is_safe when the game can't be won yet\"\"\"
+    for unbanked in (3, 12, 19, 20, 28):
+        expected = "continue" if is_safe(unbanked) else "bank"
+        check(
+            decide(unbanked, 10),
+            expected,
+            name=f"decide({unbanked}, 10) agrees with is_safe({unbanked})",
+        )
 """,
-        "starter_code": """\
-def find_leader(banked_money):
-    # Return the NAME of the player with the most banked money.
-    # Loop over the dictionary and track the best name you have
-    # seen so far, and how much money that player had.
-    pass  # Replace this line with your code
-""",
-        "test_cases": [
-            {
-                "name": "leader in the middle",
-                "args": [{"Alice": 30, "Bob": 55, "Cara": 41}],
-                "expected": "Bob",
-            },
-            {
-                "name": "leader listed first",
-                "args": [{"Dana": 72, "Eli": 4, "Flo": 40}],
-                "expected": "Dana",
-            },
-            {
-                "name": "leader listed last",
-                "args": [{"Alice": 12, "Bob": 15, "Cara": 60}],
-                "expected": "Cara",
-            },
-            {
-                "name": "only one player",
-                "args": [{"Alice": 90}],
-                "expected": "Alice",
-            },
-        ],
-    },
-    # 7 ------------------------------------------------------------------
-    {
-        "title": "Still Rolling",
-        "entry_function": "still_rolling",
-        "problem_markdown": """\
-# Still Rolling
-
-Greedy Pig's `game_state` includes `players_banked_this_round` — a
-**list** of the players who have already banked and are safely out of the
-round. Everyone else is still rolling and still at risk. Knowing how many
-rivals are still in the round is a key strategic signal.
-
-## The Task
-
-Write a function `still_rolling(players, players_banked_this_round)` that
-returns a **list** of the names in `players` that are *not* in
-`players_banked_this_round`, keeping the same order as `players`.
-
-## Examples
-
-```python
-still_rolling(["Alice", "Bob", "Cara"], ["Bob"])
-# ["Alice", "Cara"]
-
-still_rolling(["Alice", "Bob"], [])
-# ["Alice", "Bob"]
-
-still_rolling(["Alice", "Bob"], ["Alice", "Bob"])
-# []
-```
-
-## Hints
-
-- `in` and `not in` work on lists too: `"Bob" not in banked` is `True`
-  when Bob hasn't banked.
-- Start with an empty list and `append` the names that should keep
-  rolling.
-""",
-        "starter_code": """\
-def still_rolling(players, players_banked_this_round):
-    # Build and return a list of the players who have NOT banked yet,
-    # in the same order they appear in `players`.
-    pass  # Replace this line with your code
-""",
-        "test_cases": [
-            {
-                "name": "one player has banked",
-                "args": [["Alice", "Bob", "Cara"], ["Bob"]],
-                "expected": ["Alice", "Cara"],
-            },
-            {
-                "name": "nobody has banked yet",
-                "args": [["Alice", "Bob"], []],
-                "expected": ["Alice", "Bob"],
-            },
-            {
-                "name": "everyone has banked",
-                "args": [["Alice", "Bob"], ["Alice", "Bob"]],
-                "expected": [],
-            },
-            {
-                "name": "keeps the original order",
-                "args": [["Dana", "Eli", "Flo", "Gus"], ["Eli", "Dana"]],
-                "expected": ["Flo", "Gus"],
-            },
-        ],
-    },
-    # 8 ------------------------------------------------------------------
-    {
-        "title": "Everyone's Total",
-        "entry_function": "all_totals",
-        "problem_markdown": """\
-# Everyone's Total
-
-You already added banked + unbanked for **one** player. A serious agent
-sizes up the *whole table* at once: it builds a **new dictionary** with
-every player's true total. This "combine two dictionaries into one" move
-is the heart of ranking players, which comes next.
-
-## The Task
-
-Write a function `all_totals(banked_money, unbanked_money)` that returns
-a **new dictionary** mapping every player's name to their banked money
-plus their unbanked money.
-
-Both dictionaries always contain exactly the same names.
-
-## Examples
-
-```python
-all_totals({"Alice": 40, "Bob": 10}, {"Alice": 7, "Bob": 5})
-# {"Alice": 47, "Bob": 15}
-```
-
-## Hints
-
-- Start with an empty dictionary: `totals = {}`.
-- Loop over the names in `banked_money`, and for each name store
-  `totals[name] = ...`.
-""",
-        "starter_code": """\
-def all_totals(banked_money, unbanked_money):
-    # Return a NEW dictionary: every player's name mapped to
-    # their banked money plus their unbanked money.
-    pass  # Replace this line with your code
-""",
-        "test_cases": [
-            {
-                "name": "combines two players",
-                "args": [{"Alice": 40, "Bob": 10}, {"Alice": 7, "Bob": 5}],
-                "expected": {"Alice": 47, "Bob": 15},
-            },
-            {
-                "name": "three players, some zeros",
-                "args": [
-                    {"Alice": 0, "Bob": 20, "Cara": 55},
-                    {"Alice": 13, "Bob": 0, "Cara": 6},
-                ],
-                "expected": {"Alice": 13, "Bob": 20, "Cara": 61},
-            },
-            {
-                "name": "single player",
-                "args": [{"Dana": 33}, {"Dana": 9}],
-                "expected": {"Dana": 42},
-            },
-        ],
-    },
-    # 9 ------------------------------------------------------------------
-    {
-        "title": "What's My Rank?",
-        "entry_function": "my_rank",
-        "problem_markdown": """\
-# What's My Rank?
-
-Now for the real thing. Greedy Pig passes your agent one **nested**
-dictionary called `game_state`. The money dictionaries you've been
-working with live *inside* it:
-
-```python
-game_state = {
-    "round_no": 3,
-    "roll_no": 2,
-    "players_banked_this_round": [],
-    "banked_money": {"Alice": 40, "Bob": 55, "Cara": 10},
-    "unbanked_money": {"Alice": 20, "Bob": 0, "Cara": 12},
-}
-```
-
-So `game_state["banked_money"]["Bob"]` digs two levels down to get 55.
-
-The built-in `Player` class in Greedy Pig has a `my_rank` helper — here
-you build it yourself so you understand exactly what it does.
-
-## The Task
-
-Write a function `my_rank(game_state, name)` that returns the player's
-rank by **total** money (banked + unbanked): `1` means the richest player
-at the table, `2` the second richest, and so on.
-
-In every test exactly one player holds each rank — no ties.
-
-In the example above the totals are Alice 60, Bob 55, Cara 22, so
-`my_rank(game_state, "Alice")` is `1` even though Bob has more *banked* —
-unbanked money still counts toward rank.
-
-## Hints
-
-- Pull out the inner dictionaries first:
-  `banked = game_state["banked_money"]`.
-- Build each player's total, exactly like *Everyone's Total*.
-- Count how many players have a total **bigger** than yours — your rank
-  is that count plus 1. (Sorting the totals works too.)
-""",
-        "starter_code": """\
-def my_rank(game_state, name):
-    # Step 1: get the "banked_money" and "unbanked_money"
-    #         dictionaries out of game_state.
-    # Step 2: work out every player's total money.
-    # Step 3: return this player's rank: 1 = richest at the table.
-    pass  # Replace this line with your code
-""",
-        "test_cases": [
-            {
-                "name": "highest total is rank 1",
-                "args": [
-                    {
-                        "round_no": 3,
-                        "roll_no": 2,
-                        "players_banked_this_round": [],
-                        "banked_money": {"Alice": 40, "Bob": 55, "Cara": 10},
-                        "unbanked_money": {"Alice": 20, "Bob": 0, "Cara": 12},
-                    },
-                    "Alice",
-                ],
-                "expected": 1,
-            },
-            {
-                "name": "most banked is not always rank 1",
-                "args": [
-                    {
-                        "round_no": 3,
-                        "roll_no": 2,
-                        "players_banked_this_round": [],
-                        "banked_money": {"Alice": 40, "Bob": 55, "Cara": 10},
-                        "unbanked_money": {"Alice": 20, "Bob": 0, "Cara": 12},
-                    },
-                    "Bob",
-                ],
-                "expected": 2,
-            },
-            {
-                "name": "poorest player is last",
-                "args": [
-                    {
-                        "round_no": 3,
-                        "roll_no": 2,
-                        "players_banked_this_round": [],
-                        "banked_money": {"Alice": 40, "Bob": 55, "Cara": 10},
-                        "unbanked_money": {"Alice": 20, "Bob": 0, "Cara": 12},
-                    },
-                    "Cara",
-                ],
-                "expected": 3,
-            },
-            {
-                "name": "unbanked money can put you in front",
-                "args": [
-                    {
-                        "round_no": 7,
-                        "roll_no": 5,
-                        "players_banked_this_round": ["Dana"],
-                        "banked_money": {"Dana": 70, "Eli": 45},
-                        "unbanked_money": {"Dana": 0, "Eli": 30},
-                    },
-                    "Eli",
-                ],
-                "expected": 1,
-            },
-            {
-                "name": "banking early can cost the lead",
-                "args": [
-                    {
-                        "round_no": 7,
-                        "roll_no": 5,
-                        "players_banked_this_round": ["Dana"],
-                        "banked_money": {"Dana": 70, "Eli": 45},
-                        "unbanked_money": {"Dana": 0, "Eli": 30},
-                    },
-                    "Dana",
-                ],
-                "expected": 2,
-            },
-        ],
-    },
-    # 10 -----------------------------------------------------------------
-    {
-        "title": "Make the Decision",
-        "entry_function": "make_decision",
-        "problem_markdown": """\
-# Make the Decision
-
-The capstone. This is (almost) exactly the method a real Greedy Pig agent
-implements: read the nested `game_state`, do some arithmetic, and answer
-`"bank"` or `"continue"`. The only difference is that in the real game
-your name arrives as `self.name` — here it is passed in as an argument.
-
-## The Task
-
-Write a function `make_decision(game_state, name)` that applies these
-rules **in order** and returns the first one that fires:
-
-1. If banking now would give you 100 or more banked in total
-   (your banked + your unbanked ≥ 100) → return `"bank"` — that wins the
-   game!
-2. If your unbanked money is 30 or more → return `"bank"` — too much to
-   risk on one roll.
-3. If **2 or more** players have already banked this round *and* your
-   unbanked money is 15 or more → return `"bank"` — the odds no longer
-   favour the greedy.
-4. Otherwise → return `"continue"`.
-
-`game_state` has the full shape you saw in *What's My Rank?*:
-`round_no`, `roll_no`, `players_banked_this_round` (a list),
-`banked_money` and `unbanked_money` (nested dictionaries).
-
-## Examples
-
-```python
-game_state = {
-    "round_no": 9,
-    "roll_no": 4,
-    "players_banked_this_round": [],
-    "banked_money": {"Alice": 80, "Bob": 60},
-    "unbanked_money": {"Alice": 25, "Bob": 10},
-}
-
-make_decision(game_state, "Alice")
-# "bank"      (80 + 25 = 105 — banking now wins)
-
-make_decision(game_state, "Bob")
-# "continue"  (70 total, only 10 at risk, nobody has banked)
-```
-
-## Hints
-
-- Dig your two numbers out first:
-  `my_banked = game_state["banked_money"][name]` and the same for
-  unbanked. The rules become one short `if`/`elif`/`else` chain.
-- `len(game_state["players_banked_this_round"])` counts how many players
-  have banked this round.
-- Check the rules in the order given — rule 1 beats rule 4 even on
-  roll 1.
-""",
-        "starter_code": """\
-def make_decision(game_state, name):
-    # Step 1: get YOUR banked and unbanked money out of the
-    #         nested dictionaries in game_state.
-    # Step 2: count how many players have banked this round.
-    # Step 3: apply the four rules from the problem, in order,
-    #         and return "bank" or "continue".
-    pass  # Replace this line with your code
-""",
-        "test_cases": [
-            {
-                "name": "banking now wins the game",
-                "args": [
-                    {
-                        "round_no": 9,
-                        "roll_no": 4,
-                        "players_banked_this_round": [],
-                        "banked_money": {"Alice": 80, "Bob": 60},
-                        "unbanked_money": {"Alice": 25, "Bob": 10},
-                    },
-                    "Alice",
-                ],
-                "expected": "bank",
-            },
-            {
-                "name": "safe position keeps rolling",
-                "args": [
-                    {
-                        "round_no": 9,
-                        "roll_no": 4,
-                        "players_banked_this_round": [],
-                        "banked_money": {"Alice": 80, "Bob": 60},
-                        "unbanked_money": {"Alice": 25, "Bob": 10},
-                    },
-                    "Bob",
-                ],
-                "expected": "continue",
-            },
-            {
-                "name": "30 unbanked is too much to risk",
-                "args": [
-                    {
-                        "round_no": 2,
-                        "roll_no": 6,
-                        "players_banked_this_round": ["Cara"],
-                        "banked_money": {"Alice": 10, "Bob": 20, "Cara": 30},
-                        "unbanked_money": {"Alice": 30, "Bob": 14, "Cara": 0},
-                    },
-                    "Alice",
-                ],
-                "expected": "bank",
-            },
-            {
-                "name": "one banker is not enough pressure",
-                "args": [
-                    {
-                        "round_no": 2,
-                        "roll_no": 6,
-                        "players_banked_this_round": ["Cara"],
-                        "banked_money": {"Alice": 10, "Bob": 20, "Cara": 30},
-                        "unbanked_money": {"Alice": 30, "Bob": 14, "Cara": 0},
-                    },
-                    "Bob",
-                ],
-                "expected": "continue",
-            },
-            {
-                "name": "two bankers plus 15 unbanked banks",
-                "args": [
-                    {
-                        "round_no": 5,
-                        "roll_no": 3,
-                        "players_banked_this_round": ["Bob", "Cara"],
-                        "banked_money": {
-                            "Alice": 50,
-                            "Bob": 40,
-                            "Cara": 35,
-                            "Dan": 20,
-                        },
-                        "unbanked_money": {
-                            "Alice": 15,
-                            "Bob": 0,
-                            "Cara": 0,
-                            "Dan": 8,
-                        },
-                    },
-                    "Alice",
-                ],
-                "expected": "bank",
-            },
-            {
-                "name": "two bankers but a small pile rolls on",
-                "args": [
-                    {
-                        "round_no": 5,
-                        "roll_no": 3,
-                        "players_banked_this_round": ["Bob", "Cara"],
-                        "banked_money": {
-                            "Alice": 50,
-                            "Bob": 40,
-                            "Cara": 35,
-                            "Dan": 20,
-                        },
-                        "unbanked_money": {
-                            "Alice": 15,
-                            "Bob": 0,
-                            "Cara": 0,
-                            "Dan": 8,
-                        },
-                    },
-                    "Dan",
-                ],
-                "expected": "continue",
-            },
-        ],
     },
 ]
 
@@ -948,14 +509,13 @@ def seed_tutorial() -> bool:
                     title="",
                     problem_markdown="",
                     entry_function="",
-                    test_cases=[],
                 )
             exercise.order_index = index
             exercise.title = spec["title"]
             exercise.problem_markdown = spec["problem_markdown"]
             exercise.starter_code = spec["starter_code"]
             exercise.entry_function = spec["entry_function"]
-            exercise.test_cases = spec["test_cases"]
+            exercise.test_code = spec["test_code"]
             session.add(exercise)
 
         for leftover in existing[len(EXERCISES):]:

--- a/backend/scripts/seed_tutorial.py
+++ b/backend/scripts/seed_tutorial.py
@@ -516,6 +516,9 @@ def seed_tutorial() -> bool:
             exercise.starter_code = spec["starter_code"]
             exercise.entry_function = spec["entry_function"]
             exercise.test_code = spec["test_code"]
+            # The seed is a full overwrite: a spec without a solution resets
+            # any solution saved through the admin editor.
+            exercise.solution = spec.get("solution")
             session.add(exercise)
 
         for leftover in existing[len(EXERCISES):]:

--- a/backend/tasks/exercise_task.py
+++ b/backend/tasks/exercise_task.py
@@ -6,25 +6,25 @@ never reaches a worker. The task executes the student's code inside a worker
 child process; worker_max_tasks_per_child=1 gives every task a fresh process,
 so submitted code cannot contaminate later runs.
 
-Exercises are function I/O tests: the student's code must define the exercise's
-entry function, and each test case calls it with `args` and compares the return
-value to `expected` with ==. A failing test is a normal outcome ("status":
-"success", test not passed) — "status": "error" means the code never got as far
-as producing test results (syntax error, missing function, timeout).
+An exercise's tests are an admin-trusted Python test script
+(backend/tasks/exercise_test_code.py) exec'd into the same namespace as the
+student's code. A failing check is a normal outcome ("status": "success",
+test not passed) — "status": "error" means the code never got as far as
+producing test results (syntax error, missing function, timeout).
 """
 
 import contextlib
-import copy
 import io
 import time
 import traceback as tb
-from typing import Any, Dict, List
+from typing import Any, Dict, Optional
 
 from billiard.exceptions import WorkerLostError
 from celery.exceptions import SoftTimeLimitExceeded, TimeLimitExceeded
 
 from backend.tasks.celery_app import celery_app
 from backend.tasks.celery_utils import poll_task_result
+from backend.tasks.exercise_test_code import MAX_STDOUT_CHARS, run_test_code
 from backend.tasks.validation_task import (
     VALIDATION_RESULT_TIMEOUT,
     VALIDATION_TASK_EXPIRES,
@@ -42,10 +42,6 @@ EXERCISE_TIMEOUT_SECONDS = 1
 # VALIDATION_TIME_LIMIT: student code with a bare `except Exception` swallows
 # SoftTimeLimitExceeded, and only the hard kill reliably reaps a spinner.
 EXERCISE_TIME_LIMIT = EXERCISE_TIMEOUT_SECONDS + 1
-
-# Students print-debug; keep captured output bounded so a print inside a loop
-# can't bloat the result payload through the broker.
-MAX_STDOUT_CHARS = 10_000
 
 _plural = "" if EXERCISE_TIMEOUT_SECONDS == 1 else "s"
 EXERCISE_TIMEOUT_MESSAGE = (
@@ -72,7 +68,9 @@ def timeout_exercise_result() -> Dict[str, Any]:
     return _normalize({"status": "error", "message": EXERCISE_TIMEOUT_MESSAGE})
 
 
-def enqueue_exercise_run(code: str, entry_function: str, test_cases: List[dict]):
+def enqueue_exercise_run(
+    code: str, entry_function: str, test_code: Optional[str]
+):
     """Enqueue an exercise run that self-drops if it waits out its usefulness.
 
     Same expiry rationale as enqueue_validation: a task still queued after the
@@ -82,7 +80,7 @@ def enqueue_exercise_run(code: str, entry_function: str, test_cases: List[dict])
         kwargs={
             "code": code,
             "entry_function": entry_function,
-            "test_cases": test_cases,
+            "test_code": test_code,
         },
         expires=VALIDATION_TASK_EXPIRES,
     )
@@ -106,14 +104,10 @@ async def await_exercise_result(
         )
 
 
-def _format_call(entry_function: str, args: List[Any]) -> str:
-    return f"{entry_function}({', '.join(repr(a) for a in args)})"
-
-
 def _execute_tests(
-    code: str, entry_function: str, test_cases: List[dict]
+    code: str, entry_function: str, test_code: Optional[str]
 ) -> Dict[str, Any]:
-    """Exec the student's code, run every test case, return the raw result."""
+    """Exec the student's code, run the test script, return the raw result."""
     t0 = time.perf_counter()
     namespace: Dict[str, Any] = {"__name__": "exercise_submission"}
     try:
@@ -134,32 +128,19 @@ def _execute_tests(
             "message": f"Your code must define a function named '{entry_function}'.",
         }
 
-    test_results = []
-    for case in test_cases:
-        # deepcopy so a function that mutates its arguments can't leak state
-        # into (or corrupt) later test cases
-        args = copy.deepcopy(case.get("args", []))
-        expected = case.get("expected")
-        entry = {
-            "name": case.get("name") or _format_call(entry_function, args),
-            "call": _format_call(entry_function, case.get("args", [])),
-            "expected": expected,
-            "actual": None,
-            "passed": False,
-            "error": None,
+    test_results: list = []
+    if test_code:
+        error = run_test_code(test_code, namespace, test_results)
+        if error:
+            return error
+
+    if not test_results:
+        # A missing/row-less test script would otherwise pass vacuously; this
+        # is an authoring bug, not a student failure — surface it loudly.
+        return {
+            "status": "error",
+            "message": "This exercise defines no tests.",
         }
-        try:
-            actual = func(*args)
-            entry["actual"] = repr(actual)
-            entry["passed"] = bool(actual == expected)
-        except SoftTimeLimitExceeded:
-            # The budget covers the whole run — swallowing this as a per-test
-            # error would call the (likely still spinning) function again and
-            # defer the kill to the hard limit's SIGKILL.
-            raise
-        except Exception as e:  # noqa: BLE001 - a crash fails this test only
-            entry["error"] = f"{type(e).__name__}: {e}"
-        test_results.append(entry)
 
     return {
         "status": "success",
@@ -175,14 +156,14 @@ def _execute_tests(
     time_limit=EXERCISE_TIME_LIMIT,
 )
 def run_exercise(
-    code: str, entry_function: str, test_cases: List[dict]
+    code: str, entry_function: str, test_code: Optional[str]
 ) -> Dict[str, Any]:
-    """Execute the student's code and run every test case against it."""
+    """Execute the student's code and run the exercise's test script on it."""
     buf = io.StringIO()
     result: Dict[str, Any]
     try:
         with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
-            result = _execute_tests(code, entry_function, test_cases)
+            result = _execute_tests(code, entry_function, test_code)
     except SoftTimeLimitExceeded:
         # Only reached when the student's code didn't swallow it; a bare
         # `except Exception` in their code spins on until the hard time_limit

--- a/backend/tasks/exercise_test_code.py
+++ b/backend/tasks/exercise_test_code.py
@@ -1,0 +1,189 @@
+"""Runner for an exercise's optional Python test script (`Exercise.test_code`).
+
+The script is admin-trusted (seed/admin authored, students never touch it), so
+it does NOT go through validate_code — it legitimately needs things the
+student allowlist forbids. It is exec'd into the same namespace as the
+student's code, so test functions call student functions by name.
+
+The script defines `test_*` functions and uses three injected helpers:
+
+- check(actual, expected, name=None) — append one pass/fail result row
+- check_output(text, expected, name=None) — whitespace-tolerant text compare
+- capture() — context manager capturing stdout, exposing `.text`
+
+Result rows have the exact shape the JSON-case loop produces
+({name, call, expected, actual, passed, error}), so the frontend renders both
+kinds identically.
+"""
+
+import contextlib
+import io
+import json
+import traceback as tb
+from typing import Any, Dict, List, Optional
+
+from celery.exceptions import SoftTimeLimitExceeded
+
+# Students print-debug; keep captured output bounded so a print inside a loop
+# can't bloat the result payload through the broker. (Defined here rather than
+# in exercise_task to keep the import direction one-way; exercise_task
+# re-exports it.)
+MAX_STDOUT_CHARS = 10_000
+
+
+def _jsonable(value: Any) -> Any:
+    """A value safe for Celery's JSON result serialization.
+
+    Round-trips through JSON so a row looks the same whether the task ran
+    in-process (unit tests) or through the broker (a tuple `expected` is a
+    list either way); a value JSON can't encode at all (a set, an object)
+    falls back to its repr instead of crashing the task result.
+    """
+    try:
+        return json.loads(json.dumps(value))
+    except (TypeError, ValueError):
+        return repr(value)
+
+
+def _normalize_output(text: str) -> str:
+    """Whitespace-tolerant form: strip trailing whitespace per line and
+    tolerate one trailing newline."""
+    lines = [line.rstrip() for line in text.split("\n")]
+    if lines and lines[-1] == "":
+        lines.pop()
+    return "\n".join(lines)
+
+
+class _Capture:
+    """Context manager wrapping redirect_stdout into a StringIO.
+
+    Nests correctly inside the task's global capture: the innermost redirect
+    wins for its block, so captured prints don't leak into the run's stdout
+    panel.
+    """
+
+    def __init__(self) -> None:
+        self._buf = io.StringIO()
+        self._redirect = contextlib.redirect_stdout(self._buf)
+
+    def __enter__(self) -> "_Capture":
+        self._redirect.__enter__()
+        return self
+
+    def __exit__(self, *exc_info) -> bool:
+        return self._redirect.__exit__(*exc_info)
+
+    @property
+    def text(self) -> str:
+        return self._buf.getvalue()[:MAX_STDOUT_CHARS]
+
+
+def _display_name(func) -> str:
+    """A test function's user-facing name: first docstring line, else name."""
+    doc = (func.__doc__ or "").strip()
+    return doc.splitlines()[0] if doc else func.__name__
+
+
+def _error_text(e: BaseException) -> str:
+    msg = str(e)
+    return f"{type(e).__name__}: {msg}" if msg else type(e).__name__
+
+
+def run_test_code(
+    test_code: str,
+    namespace: Dict[str, Any],
+    test_results: List[dict],
+) -> Optional[Dict[str, Any]]:
+    """Exec `test_code` into the student namespace and run its test functions.
+
+    Appends result rows to `test_results` as checks run. Returns None
+    normally; an error dict (the task's "status": "error" shape) only when
+    the script itself fails to exec — an authoring bug, not a student
+    failure.
+    """
+    # The current test's display name doubles as the default row name for
+    # anonymous check()/check_output() calls inside it.
+    state: Dict[str, Optional[str]] = {"current": None}
+
+    def _append_row(name, expected, actual, passed, error=None) -> None:
+        test_results.append(
+            {
+                "name": name or state["current"] or "check",
+                "call": None,
+                "expected": expected,
+                "actual": actual,
+                "passed": passed,
+                "error": error,
+            }
+        )
+
+    def check(actual: Any, expected: Any, name: Optional[str] = None) -> bool:
+        """Record one comparison row; never raises, so later checks in the
+        same test still run."""
+        try:
+            passed = bool(actual == expected)
+            error = None
+        except Exception as e:  # noqa: BLE001 - a broken __eq__ fails the row
+            passed = False
+            error = _error_text(e)
+        _append_row(name, _jsonable(expected), repr(actual), passed, error)
+        return passed
+
+    def check_output(
+        text: Any, expected: str, name: Optional[str] = None
+    ) -> bool:
+        """Whitespace-tolerant text comparison, recorded with the raw text
+        (not repr) so the UI can show real output."""
+        # Accept a still-open capture() object where its .text was meant.
+        if isinstance(text, _Capture):
+            text = text.text
+        try:
+            passed = _normalize_output(text) == _normalize_output(expected)
+            error = None
+        except Exception as e:  # noqa: BLE001 - non-str input fails the row
+            passed = False
+            error = _error_text(e)
+        _append_row(name, expected, text, passed, error)
+        return passed
+
+    def capture() -> _Capture:
+        return _Capture()
+
+    namespace["check"] = check
+    namespace["check_output"] = check_output
+    namespace["capture"] = capture
+
+    # Snapshot before exec: only test_* callables the script itself defined
+    # (or redefined) are collected, so a student defining their own test_foo
+    # can neither inject rows nor shadow a real test.
+    before = dict(namespace)
+    try:
+        exec(test_code, namespace)  # noqa: S102 - admin-trusted script
+    except SoftTimeLimitExceeded:
+        raise
+    except Exception:
+        return {
+            "status": "error",
+            "message": "This exercise's test script failed to run.",
+            "traceback": tb.format_exc(),
+        }
+
+    tests = [
+        value
+        for key, value in namespace.items()
+        if key.startswith("test_")
+        and callable(value)
+        and before.get(key) is not value
+    ]
+
+    for func in tests:
+        state["current"] = _display_name(func)
+        try:
+            func()
+        except SoftTimeLimitExceeded:
+            # Same rule as the JSON case loop: the budget covers the whole
+            # run — swallowing this would defer the kill to the hard limit.
+            raise
+        except Exception as e:  # noqa: BLE001 - a crash fails this test only
+            _append_row(state["current"], None, None, False, _error_text(e))
+    return None

--- a/backend/tests/integration/routes/demo/test_demo_router.py
+++ b/backend/tests/integration/routes/demo/test_demo_router.py
@@ -1,75 +1,38 @@
-import json
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from fastapi.testclient import TestClient
+from jose import jwt
 from sqlmodel import Session, select
 
-from backend.routes.auth.auth_config import DEMO_TOKEN_EXPIRY_MINUTES
+from backend.api import app
+from backend.routes.auth.auth_config import (
+    ALGORITHM,
+    DEMO_TOKEN_EXPIRY_MINUTES,
+    SECRET_KEY,
+)
 from backend.database.db_models import DemoUser, League, Team
-from backend.routes.auth.auth_core import create_access_token
-from backend.routes.demo.demo_db import create_demo_user, ensure_demo_leagues_exist
+from backend.routes.demo.demo_db import create_demo_user, get_or_create_demo_league
+from backend.tests.conftest import make_student_token
 from backend.time_utils import utc_now
 
 
 @pytest.fixture
-def demo_token() -> str:
-    """Create a demo token for testing"""
-    return create_access_token(
-        data={
-            "sub": "test_demo_user",
-            "role": "student",
-            "is_demo": True,
-            "exp_time": DEMO_TOKEN_EXPIRY_MINUTES,
-        },
-        expires_delta=timedelta(minutes=DEMO_TOKEN_EXPIRY_MINUTES),
-    )
-
-
-@pytest.fixture
 def demo_league(db_session: Session) -> League:
-    """Create a test demo league"""
-    league = db_session.exec(
-        select(League).where(League.name == "greedy_pig_demo")
-    ).first()
-
-    if not league:
-        league = League(
-            name="greedy_pig_demo",
-            created_date=utc_now(),
-            expiry_date=utc_now() + timedelta(days=7),
-            game="greedy_pig",
-            is_demo=True,
-        )
-        db_session.add(league)
-        db_session.commit()
-        db_session.refresh(league)
-
-    return league
+    """A demo league, created the same way the router creates it"""
+    return get_or_create_demo_league(db_session, "greedy_pig")
 
 
 @pytest.fixture
 def demo_team(db_session: Session) -> Team:
-    """Create a test demo team"""
-    # Get or create unassigned league
-    unassigned = db_session.exec(
-        select(League).where(League.name == "unassigned")
-    ).first()
+    """A demo team, created the same way the router creates it"""
+    return create_demo_user(db_session, "TestDemoUser")
 
-    if not unassigned:
-        unassigned = League(
-            name="unassigned",
-            created_date=utc_now(),
-            expiry_date=utc_now() + timedelta(days=7),
-            game="greedy_pig",
-        )
-        db_session.add(unassigned)
-        db_session.commit()
-        db_session.refresh(unassigned)
 
-    # Create demo team
-    team, _ = create_demo_user(db_session, "TestDemoUser")
-    return team
+@pytest.fixture
+def demo_team_headers(demo_team: Team) -> dict:
+    """Student headers for the demo team, carrying the is_demo claim"""
+    return {"Authorization": f"Bearer {make_student_token(demo_team)}"}
 
 
 def test_launch_demo_success(client: TestClient, db_session: Session):
@@ -137,6 +100,28 @@ def test_launch_demo_validation_errors(client: TestClient):
     assert response.status_code == 422
 
 
+def test_launch_demo_requires_unassigned_league(
+    client: TestClient, db_session: Session
+):
+    """A missing 'unassigned' league is a broken seed invariant, so it 500s.
+
+    The league is renamed rather than deleted because seeded teams FK-reference
+    it; create_demo_user looks it up by name, so this is the state it guards.
+    """
+    unassigned = db_session.exec(
+        select(League).where(League.name == "unassigned")
+    ).one()
+    unassigned.name = "unassigned_renamed"
+    db_session.add(unassigned)
+    db_session.commit()
+
+    # The `client` fixture re-raises server exceptions; this one asserts the
+    # response a real caller gets instead of a masked 200.
+    non_raising_client = TestClient(app, raise_server_exceptions=False)
+    response = non_raising_client.post("/demo/launch_demo")
+    assert response.status_code == 500
+
+
 def test_demo_leagues_creation(client: TestClient, db_session: Session):
     """Test demo leagues are created properly"""
     # Call launch demo to trigger league creation
@@ -173,9 +158,6 @@ def test_demo_authentication_lifecycle(client: TestClient, db_session: Session):
 
 def test_demo_token_includes_institution_id(client: TestClient, db_session: Session):
     """Test that demo token includes institution_id so demo users can see demo leagues"""
-    from jose import jwt
-    from backend.routes.auth.auth_config import SECRET_KEY, ALGORITHM
-
     response = client.post("/demo/launch_demo")
     assert response.status_code == 200
     token = response.json()["access_token"]
@@ -192,3 +174,50 @@ def test_demo_token_includes_institution_id(client: TestClient, db_session: Sess
     assert leagues_response.status_code == 200
     leagues = leagues_response.json()["leagues"]
     assert len(leagues) > 0, "Demo user should see demo leagues"
+
+
+def test_launch_demo_token_expiry_matches_config(client: TestClient):
+    """The token's exp and the advertised expiry both come from the demo config."""
+    response = client.post("/demo/launch_demo")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["expires_in_minutes"] == DEMO_TOKEN_EXPIRY_MINUTES
+
+    payload = jwt.decode(data["access_token"], SECRET_KEY, algorithms=[ALGORITHM])
+    expiry = datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
+    expected = utc_now() + timedelta(minutes=DEMO_TOKEN_EXPIRY_MINUTES)
+    assert abs((expiry - expected).total_seconds()) < 60
+
+
+def test_demo_user_can_join_demo_league(
+    client: TestClient, demo_team_headers: dict, demo_league: League
+):
+    """A demo user can assign itself to a demo league."""
+    response = client.post(
+        "/user/league-assign",
+        headers=demo_team_headers,
+        json={"league_id": demo_league.id},
+    )
+    assert response.status_code == 200
+    assert "assigned to league" in response.json()["message"]
+
+
+def test_demo_user_cannot_join_non_demo_league(
+    client: TestClient, db_session: Session, demo_team: Team, demo_team_headers: dict
+):
+    """A demo user is confined to demo leagues, and a rejected join changes nothing."""
+    real_league = db_session.exec(
+        select(League).where(League.name == "greedy_pig_league")
+    ).one()
+    original_league_id = demo_team.league_id
+
+    response = client.post(
+        "/user/league-assign",
+        headers=demo_team_headers,
+        json={"league_id": real_league.id},
+    )
+    assert response.status_code == 403
+    assert "demo" in response.json()["detail"].lower()
+
+    db_session.refresh(demo_team)
+    assert demo_team.league_id == original_league_id

--- a/backend/tests/integration/routes/institution/test_team_progress.py
+++ b/backend/tests/integration/routes/institution/test_team_progress.py
@@ -83,7 +83,6 @@ def progress_setup(db_session: Session) -> SimpleNamespace:
         title="Exercise One",
         problem_markdown="p",
         entry_function="solve",
-        test_cases=[],
     )
     exercise_two = Exercise(
         tutorial_id=tutorial.id,
@@ -91,7 +90,6 @@ def progress_setup(db_session: Session) -> SimpleNamespace:
         title="Exercise Two",
         problem_markdown="p",
         entry_function="solve",
-        test_cases=[],
     )
     db_session.add(exercise_one)
     db_session.add(exercise_two)

--- a/backend/tests/integration/routes/tutorial/test_tutorial_admin.py
+++ b/backend/tests/integration/routes/tutorial/test_tutorial_admin.py
@@ -17,11 +17,9 @@ EXERCISE_PAYLOAD = {
     "problem_markdown": "# Sum\n\nAdd the two numbers.",
     "starter_code": "def add(a, b):\n    pass\n",
     "entry_function": "add",
-    "test_cases": [
-        {"name": "adds small numbers", "args": [1, 2], "expected": 3},
-        {"name": "adds negatives", "args": [-1, -2], "expected": -3},
-    ],
 }
+
+SEEDED_TEST_CODE = "def test_runs():\n    check(f(), None)\n"
 
 
 @pytest.fixture
@@ -50,7 +48,7 @@ def tutorial_with_exercises(db_session: Session, tutorial: Tutorial) -> Tutorial
                 problem_markdown=f"{name} problem",
                 starter_code="def f():\n    pass\n",
                 entry_function="f",
-                test_cases=[{"name": "runs", "args": [], "expected": None}],
+                test_code=SEEDED_TEST_CODE,
             )
         )
     db_session.commit()
@@ -181,9 +179,8 @@ def test_admin_detail_includes_full_exercise_definition(
     ]
     first = detail["exercises"][0]
     assert first["entry_function"] == "f"
-    assert first["test_cases"] == [
-        {"name": "runs", "args": [], "expected": None}
-    ]
+    # The seed-managed test script stays out of the admin surface
+    assert "test_code" not in first
 
 
 def test_admin_detail_denied_for_team(client, team_headers, tutorial):
@@ -207,20 +204,12 @@ def test_create_exercise_appends_at_end(
     assert response.status_code == 200
     created = response.json()
     assert created["order_index"] == 3
-    assert created["test_cases"] == EXERCISE_PAYLOAD["test_cases"]
     assert exercise_ids_in_order(db_session, tutorial_with_exercises.id)[-1] == (
         created["id"]
     )
-
-
-def test_create_exercise_requires_test_cases(client, auth_headers, tutorial):
-    payload = {**EXERCISE_PAYLOAD, "test_cases": []}
-    response = client.post(
-        f"/tutorial/tutorial/{tutorial.id}/exercises",
-        json=payload,
-        headers=auth_headers,
-    )
-    assert response.status_code == 422
+    # Admin-created exercises start without a test script (seed-managed)
+    db_session.expire_all()
+    assert db_session.get(Exercise, created["id"]).test_code is None
 
 
 def test_create_exercise_rejects_bad_entry_function(client, auth_headers, tutorial):
@@ -248,8 +237,9 @@ def test_update_exercise_replaces_all_fields(
     exercise = db_session.get(Exercise, exercise_id)
     assert exercise.title == "Sum Two Numbers"
     assert exercise.entry_function == "add"
-    assert exercise.test_cases == EXERCISE_PAYLOAD["test_cases"]
     assert exercise.order_index == 1  # editing never moves the exercise
+    # An admin edit must never clobber the seed-managed test script
+    assert exercise.test_code == SEEDED_TEST_CODE
 
 
 def test_delete_exercise_compacts_order(

--- a/backend/tests/integration/routes/tutorial/test_tutorial_admin.py
+++ b/backend/tests/integration/routes/tutorial/test_tutorial_admin.py
@@ -17,6 +17,7 @@ EXERCISE_PAYLOAD = {
     "problem_markdown": "# Sum\n\nAdd the two numbers.",
     "starter_code": "def add(a, b):\n    pass\n",
     "entry_function": "add",
+    "test_code": "def test_adds():\n    check(add(1, 2), 3)\n",
 }
 
 SEEDED_TEST_CODE = "def test_runs():\n    check(f(), None)\n"
@@ -179,8 +180,8 @@ def test_admin_detail_includes_full_exercise_definition(
     ]
     first = detail["exercises"][0]
     assert first["entry_function"] == "f"
-    # The seed-managed test script stays out of the admin surface
-    assert "test_code" not in first
+    # The admin editor needs the test script to show and run it
+    assert first["test_code"] == SEEDED_TEST_CODE
 
 
 def test_admin_detail_denied_for_team(client, team_headers, tutorial):
@@ -207,9 +208,25 @@ def test_create_exercise_appends_at_end(
     assert exercise_ids_in_order(db_session, tutorial_with_exercises.id)[-1] == (
         created["id"]
     )
-    # Admin-created exercises start without a test script (seed-managed)
     db_session.expire_all()
-    assert db_session.get(Exercise, created["id"]).test_code is None
+    exercise = db_session.get(Exercise, created["id"])
+    assert exercise.test_code == EXERCISE_PAYLOAD["test_code"]
+
+
+def test_create_exercise_blank_test_code_stored_as_null(
+    client, auth_headers, db_session, tutorial
+):
+    """A whitespace-only script must not shadow the worker's loud
+    'defines no tests' error with a vacuous pass."""
+    payload = {**EXERCISE_PAYLOAD, "test_code": "   \n"}
+    response = client.post(
+        f"/tutorial/tutorial/{tutorial.id}/exercises",
+        json=payload,
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    db_session.expire_all()
+    assert db_session.get(Exercise, response.json()["id"]).test_code is None
 
 
 def test_create_exercise_rejects_bad_entry_function(client, auth_headers, tutorial):
@@ -238,8 +255,8 @@ def test_update_exercise_replaces_all_fields(
     assert exercise.title == "Sum Two Numbers"
     assert exercise.entry_function == "add"
     assert exercise.order_index == 1  # editing never moves the exercise
-    # An admin edit must never clobber the seed-managed test script
-    assert exercise.test_code == SEEDED_TEST_CODE
+    # PUT is a full replacement, test script included
+    assert exercise.test_code == EXERCISE_PAYLOAD["test_code"]
 
 
 def test_delete_exercise_compacts_order(
@@ -301,6 +318,90 @@ def test_reorder_rejects_incomplete_id_list(
     assert response.status_code == 400
 
 
+# -- dry run ----------------------------------------------------------------
+
+
+RUN_PAYLOAD = {
+    "code": "def add(a, b):\n    return a + b\n",
+    "entry_function": "add",
+    "test_code": (
+        "def test_adds():\n"
+        '    """adds two numbers"""\n'
+        "    check(add(1, 2), 3)\n"
+        "def test_adds_negatives():\n"
+        '    """adds negatives"""\n'
+        "    check(add(-1, -2), -3)\n"
+    ),
+}
+
+
+def test_run_exercise_passes(client, auth_headers, celery_workers):
+    response = client.post(
+        "/tutorial/admin/run-exercise", json=RUN_PAYLOAD, headers=auth_headers
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "success"
+    assert data["passed"] is True
+    assert [t["name"] for t in data["test_results"]] == [
+        "adds two numbers",
+        "adds negatives",
+    ]
+
+
+def test_run_exercise_failing_test(client, auth_headers, celery_workers):
+    payload = {**RUN_PAYLOAD, "code": "def add(a, b):\n    return a - b\n"}
+    response = client.post(
+        "/tutorial/admin/run-exercise", json=payload, headers=auth_headers
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "success"
+    assert data["passed"] is False
+
+
+def test_run_exercise_broken_test_script_returns_traceback(
+    client, auth_headers, celery_workers
+):
+    """An admin debugging their own test script gets the traceback — unlike
+    the student route, which hides it."""
+    payload = {**RUN_PAYLOAD, "test_code": "not_a_defined_helper()\n"}
+    response = client.post(
+        "/tutorial/admin/run-exercise", json=payload, headers=auth_headers
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "error"
+    assert "test script failed to run" in data["message"]
+    assert "NameError" in data["traceback"]
+
+
+def test_run_exercise_without_tests_is_an_error(
+    client, auth_headers, celery_workers
+):
+    payload = {**RUN_PAYLOAD, "test_code": None}
+    response = client.post(
+        "/tutorial/admin/run-exercise", json=payload, headers=auth_headers
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "error"
+    assert data["message"] == "This exercise defines no tests."
+
+
+def test_run_exercise_rejects_unsafe_code(client, auth_headers):
+    """Unsafe code fails the AST check in the API process — no worker
+    needed — so admins see exactly what a student submission would hit."""
+    payload = {**RUN_PAYLOAD, "code": "import os\ndef add(a, b):\n    return 0\n"}
+    response = client.post(
+        "/tutorial/admin/run-exercise", json=payload, headers=auth_headers
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "error"
+    assert data["message"].startswith("Code is not safe")
+
+
 def test_admin_endpoints_denied_for_team(
     client, team_headers, db_session, tutorial_with_exercises
 ):
@@ -313,6 +414,7 @@ def test_admin_endpoints_denied_for_team(
         ("post", f"/tutorial/tutorial/{tutorial_id}/exercises", EXERCISE_PAYLOAD),
         ("put", f"/tutorial/exercise/{exercise_id}", EXERCISE_PAYLOAD),
         ("delete", f"/tutorial/exercise/{exercise_id}", None),
+        ("post", "/tutorial/admin/run-exercise", RUN_PAYLOAD),
         (
             "post",
             f"/tutorial/tutorial/{tutorial_id}/exercises/reorder",

--- a/backend/tests/integration/routes/tutorial/test_tutorial_admin.py
+++ b/backend/tests/integration/routes/tutorial/test_tutorial_admin.py
@@ -18,6 +18,7 @@ EXERCISE_PAYLOAD = {
     "starter_code": "def add(a, b):\n    pass\n",
     "entry_function": "add",
     "test_code": "def test_adds():\n    check(add(1, 2), 3)\n",
+    "solution": "def add(a, b):\n    return a + b\n",
 }
 
 SEEDED_TEST_CODE = "def test_runs():\n    check(f(), None)\n"
@@ -211,14 +212,16 @@ def test_create_exercise_appends_at_end(
     db_session.expire_all()
     exercise = db_session.get(Exercise, created["id"])
     assert exercise.test_code == EXERCISE_PAYLOAD["test_code"]
+    assert exercise.solution == EXERCISE_PAYLOAD["solution"]
 
 
 def test_create_exercise_blank_test_code_stored_as_null(
     client, auth_headers, db_session, tutorial
 ):
     """A whitespace-only script must not shadow the worker's loud
-    'defines no tests' error with a vacuous pass."""
-    payload = {**EXERCISE_PAYLOAD, "test_code": "   \n"}
+    'defines no tests' error with a vacuous pass; a blank solution is
+    normalized the same way."""
+    payload = {**EXERCISE_PAYLOAD, "test_code": "   \n", "solution": ""}
     response = client.post(
         f"/tutorial/tutorial/{tutorial.id}/exercises",
         json=payload,
@@ -226,7 +229,9 @@ def test_create_exercise_blank_test_code_stored_as_null(
     )
     assert response.status_code == 200
     db_session.expire_all()
-    assert db_session.get(Exercise, response.json()["id"]).test_code is None
+    exercise = db_session.get(Exercise, response.json()["id"])
+    assert exercise.test_code is None
+    assert exercise.solution is None
 
 
 def test_create_exercise_rejects_bad_entry_function(client, auth_headers, tutorial):
@@ -255,8 +260,9 @@ def test_update_exercise_replaces_all_fields(
     assert exercise.title == "Sum Two Numbers"
     assert exercise.entry_function == "add"
     assert exercise.order_index == 1  # editing never moves the exercise
-    # PUT is a full replacement, test script included
+    # PUT is a full replacement, test script and solution included
     assert exercise.test_code == EXERCISE_PAYLOAD["test_code"]
+    assert exercise.solution == EXERCISE_PAYLOAD["solution"]
 
 
 def test_delete_exercise_compacts_order(

--- a/backend/tests/integration/routes/tutorial/test_tutorial_router.py
+++ b/backend/tests/integration/routes/tutorial/test_tutorial_router.py
@@ -135,6 +135,7 @@ def test_get_tutorial_detail(client, team_headers, tutorial_with_exercise):
     assert exercise["starter_code"].startswith("def count_words")
     assert "test_code" not in exercise
     assert "entry_function" not in exercise
+    assert "solution" not in exercise
 
     response = client.get("/tutorial/tutorial/99999", headers=team_headers)
     assert response.status_code == 404

--- a/backend/tests/integration/routes/tutorial/test_tutorial_router.py
+++ b/backend/tests/integration/routes/tutorial/test_tutorial_router.py
@@ -15,23 +15,25 @@ from backend.database.db_models import (
 from backend.routes.auth.auth_core import create_access_token
 from backend.time_utils import utc_now
 
-TEST_CASES = [
-    {
-        "name": "counts each word once",
-        "args": ["the cat sat"],
-        "expected": {"the": 1, "cat": 1, "sat": 1},
-    },
-    {
-        "name": "counts repeated words",
-        "args": ["the cat and the dog"],
-        "expected": {"the": 2, "cat": 1, "and": 1, "dog": 1},
-    },
-    {
-        "name": "empty string has no words",
-        "args": [""],
-        "expected": {},
-    },
-]
+WORD_COUNTER_TEST_CODE = '''\
+def test_counts_each_word_once():
+    """counts each word once"""
+    check(count_words("the cat sat"), {"the": 1, "cat": 1, "sat": 1})
+
+
+def test_counts_repeated_words():
+    """counts repeated words"""
+    check(
+        count_words("the cat and the dog"),
+        {"the": 2, "cat": 1, "and": 1, "dog": 1},
+    )
+
+
+def test_empty_string():
+    """empty string has no words"""
+    check(count_words(""), {})
+'''
+WORD_COUNTER_TEST_COUNT = 3
 
 PASSING_CODE = """
 def count_words(sentence):
@@ -75,7 +77,7 @@ def tutorial_with_exercise(db_session: Session) -> Tutorial:
         problem_markdown="Second problem",
         starter_code="def second():\n    pass\n",
         entry_function="second",
-        test_cases=[{"name": "returns none", "args": [], "expected": None}],
+        test_code="def test_returns_none():\n    check(second(), None)\n",
     )
     first = Exercise(
         tutorial_id=tutorial.id,
@@ -84,7 +86,7 @@ def tutorial_with_exercise(db_session: Session) -> Tutorial:
         problem_markdown="Count the words",
         starter_code="def count_words(sentence):\n    pass\n",
         entry_function="count_words",
-        test_cases=TEST_CASES,
+        test_code=WORD_COUNTER_TEST_CODE,
     )
     db_session.add(later)
     db_session.add(first)
@@ -131,7 +133,7 @@ def test_get_tutorial_detail(client, team_headers, tutorial_with_exercise):
     exercise = data["exercises"][0]
     assert exercise["problem_markdown"] == "Count the words"
     assert exercise["starter_code"].startswith("def count_words")
-    assert "test_cases" not in exercise
+    assert "test_code" not in exercise
     assert "entry_function" not in exercise
 
     response = client.get("/tutorial/tutorial/99999", headers=team_headers)
@@ -149,10 +151,11 @@ def test_submit_exercise_all_tests_pass(
     assert response.status_code == 200
     data = response.json()
     assert data["passed"] is True
-    assert len(data["test_results"]) == len(TEST_CASES)
+    assert len(data["test_results"]) == WORD_COUNTER_TEST_COUNT
     assert all(t["passed"] for t in data["test_results"])
 
-    # The code row is stored and linked to a metadata row
+    # The code row is stored and linked to a metadata row, with the per-test
+    # rows persisted as returned
     submission = db_session.exec(
         select(ExerciseSubmission).where(
             ExerciseSubmission.id == data["submission_id"]
@@ -160,6 +163,7 @@ def test_submit_exercise_all_tests_pass(
     ).one()
     assert submission.code == PASSING_CODE
     assert submission.passed is True
+    assert submission.test_results == data["test_results"]
     assert submission.meta.exercise_id == word_counter_exercise.id
 
 
@@ -177,6 +181,7 @@ def test_submit_exercise_failing_tests_still_stored(
     data = response.json()
     assert data["passed"] is False
 
+    # Row names come from the test functions' docstrings
     by_name = {t["name"]: t for t in data["test_results"]}
     assert by_name["counts each word once"]["passed"] is True
     assert by_name["empty string has no words"]["passed"] is True
@@ -194,6 +199,99 @@ def test_submit_exercise_failing_tests_still_stored(
     data = response.json()
     assert data["code"] == PARTIAL_CODE
     assert data["passed"] is False
+
+
+PRINT_TEST_CODE = '''\
+def test_prints_the_board():
+    """prints one line per player, in order"""
+    with capture() as out:
+        print_scores({"Alice": 30, "Bob": 55})
+    check_output(out.text, "Alice: 30\\nBob: 55")
+
+
+def test_returns_nothing():
+    """prints instead of returning"""
+    with capture() as out:
+        result = print_scores({"Alice": 30})
+    check(result, None)
+'''
+
+
+@pytest.fixture
+def print_exercise(
+    db_session: Session, tutorial_with_exercise: Tutorial
+) -> Exercise:
+    """A print-checking exercise (capture/check_output) in TeamA's tutorial."""
+    exercise = Exercise(
+        tutorial_id=tutorial_with_exercise.id,
+        order_index=2,
+        title="Print Exercise",
+        problem_markdown="Print the scoreboard",
+        starter_code="def print_scores(banked):\n    pass\n",
+        entry_function="print_scores",
+        test_code=PRINT_TEST_CODE,
+    )
+    db_session.add(exercise)
+    db_session.commit()
+    db_session.refresh(exercise)
+    return exercise
+
+
+def test_submit_print_exercise(
+    client, db_session, team_headers, print_exercise, celery_workers
+):
+    """check_output failures carry raw multiline text, prints outside the
+    tests land in the stdout panel, and the rows are stored."""
+    response = client.post(
+        "/tutorial/submit-exercise",
+        json={
+            "exercise_id": print_exercise.id,
+            "code": (
+                "print('debugging outside the tests')\n"
+                "def print_scores(banked):\n"
+                "    for name in banked:\n"
+                "        print(f'{name} has {banked[name]}')\n"
+            ),
+        },
+        headers=team_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["passed"] is False
+
+    by_name = {t["name"]: t for t in data["test_results"]}
+    failed = by_name["prints one line per player, in order"]
+    assert failed["passed"] is False
+    assert failed["expected"] == "Alice: 30\nBob: 55"
+    assert failed["actual"] == "Alice has 30\nBob has 55\n"
+    assert by_name["prints instead of returning"]["passed"] is True
+
+    # Module-level prints reach the stdout panel; captured test output doesn't
+    assert "debugging outside the tests" in data["stdout"]
+    assert "Alice has 30" not in data["stdout"]
+
+    submission = db_session.exec(
+        select(ExerciseSubmission).where(
+            ExerciseSubmission.id == data["submission_id"]
+        )
+    ).one()
+    assert submission.test_results == data["test_results"]
+
+    # And the fixed version passes
+    response = client.post(
+        "/tutorial/submit-exercise",
+        json={
+            "exercise_id": print_exercise.id,
+            "code": (
+                "def print_scores(banked):\n"
+                "    for name in banked:\n"
+                "        print(f'{name}: {banked[name]}')\n"
+            ),
+        },
+        headers=team_headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["passed"] is True
 
 
 def test_submit_exercise_unsafe_code(
@@ -482,7 +580,7 @@ def unattached_tutorial(db_session: Session) -> Tutorial:
             problem_markdown="Hidden problem",
             starter_code="def hidden():\n    pass\n",
             entry_function="hidden",
-            test_cases=[{"name": "runs", "args": [], "expected": None}],
+            test_code="def test_runs():\n    check(hidden(), None)\n",
         )
     )
     db_session.commit()

--- a/backend/tests/integration/test_game_workflows.py
+++ b/backend/tests/integration/test_game_workflows.py
@@ -4,9 +4,9 @@ from datetime import timedelta
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlmodel import Session
+from sqlmodel import Session, select
 
-from backend.tests.conftest import add_submission, build_institution
+from backend.tests.conftest import add_submission, build_institution, make_student_token
 from backend.database.db_models import League, Team
 from backend.routes.auth.auth_core import create_access_token
 from backend.time_utils import utc_now
@@ -14,7 +14,7 @@ from backend.time_utils import utc_now
 
 @pytest.fixture
 def setup_integration_team(db_session: Session, test_league: League) -> Team:
-    """Create a test team with basic submission"""
+    """Create a test team with a submission for test_league's game (greedy_pig)"""
     team = Team(
         name="integration_test_team",
         school_name="Integration Test School",
@@ -30,10 +30,12 @@ def setup_integration_team(db_session: Session, test_league: League) -> Team:
     add_submission(
         db_session,
         code="""
-from games.prisoners_dilemma.player import Player
+from games.greedy_pig.player import Player
 class CustomPlayer(Player):
     def make_decision(self, game_state):
-        return "collude"
+        if game_state["unbanked_money"][self.name] > 5:
+            return "bank"
+        return "continue"
 """,
         timestamp=utc_now(),
         team_id=team.id,
@@ -41,6 +43,12 @@ class CustomPlayer(Player):
     db_session.commit()
 
     return team
+
+
+@pytest.fixture
+def integration_team_headers(setup_integration_team: Team) -> dict:
+    """Student headers for the team created by setup_integration_team"""
+    return {"Authorization": f"Bearer {make_student_token(setup_integration_team)}"}
 
 
 def test_complete_game_lifecycle(
@@ -117,17 +125,14 @@ def test_complete_game_lifecycle(
     )
     team_headers = {"Authorization": f"Bearer {team_token}"}
 
-    # Assign team to league - may not be needed if team was created with league_id
-    try:
-        assign_response = client.post(
-            "/user/league-assign",
-            headers=team_headers,
-            json={"league_id": league_id},
-        )
-        assert assign_response.status_code == 200
-        assert "assigned to league" in assign_response.json()["message"]
-    except:
-        pass  # This might fail if team is already assigned to league
+    # Re-assign the team to the league it was created in - assignment is idempotent
+    assign_response = client.post(
+        "/user/league-assign",
+        headers=team_headers,
+        json={"league_id": league_id},
+    )
+    assert assign_response.status_code == 200
+    assert "assigned to league" in assign_response.json()["message"]
 
     # 3. Submit code
     code = """
@@ -181,3 +186,94 @@ class CustomPlayer(Player):
     results_data = results_response.json()
     assert results_data is not None
     assert "total_points" in results_data
+
+
+def test_league_assign_unknown_league(
+    client: TestClient, integration_team_headers: dict
+):
+    """Assigning to a league that doesn't exist is a 404, not a silent no-op."""
+    response = client.post(
+        "/user/league-assign",
+        headers=integration_team_headers,
+        json={"league_id": 999999},
+    )
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+def test_league_assign_keeps_team_in_original_league_on_failure(
+    client: TestClient,
+    db_session: Session,
+    setup_integration_team: Team,
+    integration_team_headers: dict,
+    test_league: League,
+):
+    """A failed assignment leaves the team's existing league untouched."""
+    response = client.post(
+        "/user/league-assign",
+        headers=integration_team_headers,
+        json={"league_id": 999999},
+    )
+    assert response.status_code == 404
+
+    db_session.refresh(setup_integration_team)
+    assert setup_integration_team.league_id == test_league.id
+
+
+def test_run_simulation_unknown_league(client: TestClient, auth_headers: dict):
+    """Simulating a league that doesn't exist is a 404 (never reaches the worker)."""
+    response = client.post(
+        "/institution/run-simulation",
+        headers=auth_headers,
+        json={"league_id": 999999, "num_simulations": 10},
+    )
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+def test_run_simulation_rejected_on_unassigned_league(
+    client: TestClient, db_session: Session, auth_headers: dict
+):
+    """The 'unassigned' holding league is protected from simulation runs."""
+    unassigned = db_session.exec(
+        select(League).where(League.name == "unassigned")
+    ).one()
+
+    response = client.post(
+        "/institution/run-simulation",
+        headers=auth_headers,
+        json={"league_id": unassigned.id, "num_simulations": 10},
+    )
+    assert response.status_code == 400
+    assert "unassigned" in response.json()["detail"].lower()
+
+
+def test_run_simulation_rejects_other_institutions_league(
+    client: TestClient, db_session: Session, test_league: League
+):
+    """An institution cannot simulate a league it doesn't own."""
+    outsider = build_institution(
+        name="outsider_institution",
+        contact_email="outsider@example.com",
+        created_date=utc_now(),
+        password_hash="test_hash",
+    )
+    db_session.add(outsider)
+    db_session.commit()
+    db_session.refresh(outsider)
+
+    outsider_token = create_access_token(
+        data={
+            "sub": "outsider_institution",
+            "role": "institution",
+            "institution_id": outsider.id,
+        },
+        expires_delta=timedelta(minutes=30),
+    )
+
+    response = client.post(
+        "/institution/run-simulation",
+        headers={"Authorization": f"Bearer {outsider_token}"},
+        json={"league_id": test_league.id, "num_simulations": 10},
+    )
+    assert response.status_code == 403

--- a/backend/tests/unit/test_exercise_task.py
+++ b/backend/tests/unit/test_exercise_task.py
@@ -2,7 +2,10 @@
 
 run_exercise is called directly (not via .delay) so the test-runner process
 executes — and coverage measures — the task body; the enqueue-to-worker path
-is exercised end-to-end by the tutorial router integration tests.
+is exercised end-to-end by the tutorial router integration tests. The test
+script helper semantics (check/check_output/capture) live in
+test_exercise_test_code.py; this file covers the task-level plumbing around
+them.
 """
 
 from unittest.mock import MagicMock
@@ -17,25 +20,31 @@ from backend.tasks.exercise_task import (
     timeout_exercise_result,
 )
 
-ADD_CASES = [{"args": [1, 2], "expected": 3}]
+ADD_CODE = "def add(a, b):\n    return a + b"
+
+ADD_TEST_CODE = (
+    "def test_add():\n"
+    '    """adds two numbers"""\n'
+    "    check(add(1, 2), 3)\n"
+)
 
 
 def test_passing_submission():
-    result = run_exercise("def add(a, b):\n    return a + b", "add", ADD_CASES)
+    result = run_exercise(ADD_CODE, "add", ADD_TEST_CODE)
     assert result["status"] == "success"
     assert result["passed"] is True
     assert result["duration_ms"] is not None
     (case,) = result["test_results"]
-    assert case["call"] == "add(1, 2)"
+    assert case["name"] == "adds two numbers"
     assert case["actual"] == "3"
 
 
 def test_failing_expectation_is_success_not_error():
-    result = run_exercise(
-        "def add(a, b):\n    return a + b",
-        "add",
-        [{"args": [1, 2], "expected": 4, "name": "custom name"}],
+    test_code = (
+        "def test_add():\n"
+        "    check(add(1, 2), 4, name='custom name')\n"
     )
+    result = run_exercise(ADD_CODE, "add", test_code)
     assert result["status"] == "success"
     assert result["passed"] is False
     assert result["test_results"][0]["name"] == "custom name"
@@ -43,31 +52,21 @@ def test_failing_expectation_is_success_not_error():
 
 def test_exception_inside_function_fails_that_test_only():
     result = run_exercise(
-        "def add(a, b):\n    raise RuntimeError('boom')", "add", ADD_CASES
+        "def add(a, b):\n    raise RuntimeError('boom')", "add", ADD_TEST_CODE
     )
     assert result["status"] == "success"
     assert result["passed"] is False
     assert result["test_results"][0]["error"] == "RuntimeError: boom"
 
 
-def test_mutating_function_cannot_corrupt_the_reported_call():
-    result = run_exercise(
-        "def total(xs):\n    xs.append(1)\n    return sum(xs)",
-        "total",
-        [{"args": [[1, 2]], "expected": 4}],
-    )
-    assert result["passed"] is True
-    assert result["test_results"][0]["call"] == "total([1, 2])"
-
-
 def test_missing_entry_function():
-    result = run_exercise("def other():\n    return 1", "add", ADD_CASES)
+    result = run_exercise("def other():\n    return 1", "add", ADD_TEST_CODE)
     assert result["status"] == "error"
     assert "must define a function named 'add'" in result["message"]
 
 
 def test_code_that_crashes_before_tests():
-    result = run_exercise("raise ValueError('bad module')", "add", ADD_CASES)
+    result = run_exercise("raise ValueError('bad module')", "add", ADD_TEST_CODE)
     assert result["status"] == "error"
     assert "failed to run before any tests started" in result["message"]
     assert "bad module" in result["traceback"]
@@ -75,9 +74,9 @@ def test_code_that_crashes_before_tests():
 
 def test_stdout_is_captured_and_bounded():
     result = run_exercise(
-        f"print('x' * {MAX_STDOUT_CHARS * 2})\ndef add(a, b):\n    return a + b",
+        f"print('x' * {MAX_STDOUT_CHARS * 2})\n{ADD_CODE}",
         "add",
-        ADD_CASES,
+        ADD_TEST_CODE,
     )
     assert result["status"] == "success"
     assert len(result["stdout"]) == MAX_STDOUT_CHARS
@@ -89,7 +88,7 @@ def test_soft_time_limit_inside_function_maps_to_timeout_message():
         "def add(a, b):\n"
         "    raise SoftTimeLimitExceeded()"
     )
-    result = run_exercise(code, "add", ADD_CASES)
+    result = run_exercise(code, "add", ADD_TEST_CODE)
     assert result["status"] == "error"
     assert result["message"] == EXERCISE_TIMEOUT_MESSAGE
 
@@ -99,16 +98,15 @@ def test_soft_time_limit_during_exec_maps_to_timeout_message():
         "from celery.exceptions import SoftTimeLimitExceeded\n"
         "raise SoftTimeLimitExceeded()"
     )
-    result = run_exercise(code, "add", ADD_CASES)
+    result = run_exercise(code, "add", ADD_TEST_CODE)
     assert result["status"] == "error"
     assert result["message"] == EXERCISE_TIMEOUT_MESSAGE
 
 
-def test_malformed_test_cases_hit_the_task_boundary_catch_all():
-    result = run_exercise("def add(a, b):\n    return a + b", "add", None)
+def test_exercise_without_test_code_is_an_authoring_error():
+    result = run_exercise(ADD_CODE, "add", None)
     assert result["status"] == "error"
-    assert "Error while running tests" in result["message"]
-    assert result["traceback"] is not None
+    assert "defines no tests" in result["message"]
 
 
 def test_timeout_exercise_result_shape():

--- a/backend/tests/unit/test_exercise_test_code.py
+++ b/backend/tests/unit/test_exercise_test_code.py
@@ -1,0 +1,200 @@
+"""Unit tests for the exercise test-script runner (exercise_test_code.py).
+
+Everything goes through run_exercise so the rows tested here are exactly the
+rows the API returns and the frontend renders.
+"""
+
+import json
+
+from backend.tasks.exercise_task import (
+    EXERCISE_TIMEOUT_MESSAGE,
+    run_exercise,
+)
+from backend.tasks.exercise_test_code import MAX_STDOUT_CHARS
+
+ADD_CODE = "def add(a, b):\n    return a + b"
+
+ROW_KEYS = {"name", "call", "expected", "actual", "passed", "error"}
+
+
+def test_check_rows_have_the_full_row_shape():
+    test_code = (
+        "def test_math():\n"
+        "    check(add(1, 2), 3, name='one plus two')\n"
+        "    check(add(2, 2), 5, name='two plus two, wrong')\n"
+    )
+    result = run_exercise(ADD_CODE, "add", test_code)
+    assert result["status"] == "success"
+    assert result["passed"] is False
+    passing, failing = result["test_results"]
+    assert set(passing) == ROW_KEYS and set(failing) == ROW_KEYS
+    assert passing == {
+        "name": "one plus two",
+        "call": None,
+        "expected": 3,
+        "actual": "3",
+        "passed": True,
+        "error": None,
+    }
+    # check() must not raise on failure: the second row exists and records
+    # the mismatch.
+    assert failing["passed"] is False
+    assert failing["expected"] == 5
+    assert failing["actual"] == "4"
+
+
+def test_unnamed_check_row_is_named_from_the_docstring():
+    test_code = (
+        "def test_add():\n"
+        '    """adds small numbers"""\n'
+        "    check(add(1, 2), 3)\n"
+    )
+    result = run_exercise(ADD_CODE, "add", test_code)
+    assert result["test_results"][0]["name"] == "adds small numbers"
+
+
+def test_check_output_tolerates_trailing_whitespace_and_newline():
+    test_code = (
+        "def test_out():\n"
+        "    check_output('Alice: 30  \\nBob: 55\\n', 'Alice: 30\\nBob: 55')\n"
+    )
+    result = run_exercise(ADD_CODE, "add", test_code)
+    assert result["passed"] is True
+
+
+def test_check_output_mismatch_records_raw_text():
+    test_code = (
+        "def test_out():\n"
+        "    check_output('Alice: 99\\n', 'Alice: 30\\nBob: 55', name='board')\n"
+    )
+    result = run_exercise(ADD_CODE, "add", test_code)
+    assert result["passed"] is False
+    (row,) = result["test_results"]
+    # Raw text, not repr — the UI shows real newlines.
+    assert row["expected"] == "Alice: 30\nBob: 55"
+    assert row["actual"] == "Alice: 99\n"
+
+
+def test_capture_truncates_at_max_stdout_chars():
+    test_code = (
+        "def test_big():\n"
+        "    with capture() as out:\n"
+        f"        print('x' * {MAX_STDOUT_CHARS * 2})\n"
+        f"    check(len(out.text), {MAX_STDOUT_CHARS})\n"
+    )
+    result = run_exercise(ADD_CODE, "add", test_code)
+    assert result["passed"] is True
+
+
+def test_captured_output_stays_out_of_the_stdout_panel():
+    test_code = (
+        "def test_quiet():\n"
+        "    with capture() as out:\n"
+        "        print('hidden from the panel')\n"
+        "    check_output(out.text, 'hidden from the panel')\n"
+    )
+    result = run_exercise(ADD_CODE, "add", test_code)
+    assert result["passed"] is True
+    assert result["stdout"] is None
+
+
+def test_uncaught_exception_becomes_error_row_named_from_docstring():
+    test_code = (
+        "def test_boom():\n"
+        '    """explodes helpfully"""\n'
+        "    raise ValueError('bad')\n"
+    )
+    result = run_exercise(ADD_CODE, "add", test_code)
+    assert result["status"] == "success"
+    assert result["passed"] is False
+    (row,) = result["test_results"]
+    assert row["name"] == "explodes helpfully"
+    assert row["error"] == "ValueError: bad"
+
+
+def test_bare_failing_assert_falls_back_to_function_name():
+    test_code = "def test_assertion():\n    assert add(1, 1) == 3\n"
+    result = run_exercise(ADD_CODE, "add", test_code)
+    (row,) = result["test_results"]
+    assert row["name"] == "test_assertion"
+    assert row["error"] == "AssertionError"
+    assert row["passed"] is False
+
+
+def test_student_defined_test_functions_are_not_collected():
+    student = (
+        f"{ADD_CODE}\n"
+        "def test_sneaky():\n"
+        "    raise RuntimeError('student test ran')\n"
+    )
+    test_code = "def test_real():\n    check(add(1, 2), 3)\n"
+    result = run_exercise(student, "add", test_code)
+    assert result["passed"] is True
+    assert len(result["test_results"]) == 1
+
+
+def test_student_predefined_name_cannot_shadow_a_script_test():
+    """A student defining test_real themselves must not suppress the script's
+    test_real (redefined names are still collected)."""
+    student = f"{ADD_CODE}\ndef test_real():\n    pass\n"
+    test_code = "def test_real():\n    check(add(2, 2), 5)\n"
+    result = run_exercise(student, "add", test_code)
+    assert result["passed"] is False
+    assert len(result["test_results"]) == 1
+
+
+def test_soft_time_limit_inside_a_test_function_propagates():
+    test_code = (
+        "from celery.exceptions import SoftTimeLimitExceeded\n"
+        "def test_spin():\n"
+        "    raise SoftTimeLimitExceeded()\n"
+    )
+    result = run_exercise(ADD_CODE, "add", test_code)
+    assert result["status"] == "error"
+    assert result["message"] == EXERCISE_TIMEOUT_MESSAGE
+
+
+def test_tuple_expected_is_sanitized_and_result_serializes():
+    student = "def make():\n    return (2, 3)"
+    test_code = "def test_pair():\n    check(make(), (2, 3))\n"
+    result = run_exercise(student, "make", test_code)
+    assert result["passed"] is True
+    (row,) = result["test_results"]
+    # Recorded in wire format: same row in-process as through the broker
+    assert row["expected"] == [2, 3]
+    json.dumps(result)  # the whole payload must survive the result backend
+
+
+def test_unserializable_expected_falls_back_to_repr():
+    student = "def make():\n    return {2, 3}"
+    test_code = "def test_set():\n    check(make(), {2, 3})\n"
+    result = run_exercise(student, "make", test_code)
+    assert result["passed"] is True  # compared before sanitizing
+    (row,) = result["test_results"]
+    assert row["expected"] == repr({2, 3})
+    json.dumps(result)
+
+
+def test_script_exec_error_is_an_authoring_error():
+    result = run_exercise(ADD_CODE, "add", "this is not python")
+    assert result["status"] == "error"
+    assert "test script failed to run" in result["message"]
+    assert result["traceback"] is not None
+
+
+def test_rowless_script_hits_the_no_tests_guard():
+    result = run_exercise(ADD_CODE, "add", "def test_nothing():\n    pass\n")
+    assert result["status"] == "error"
+    assert "defines no tests" in result["message"]
+
+
+def test_check_output_accepts_the_capture_object_itself():
+    student = "def greet():\n    print('hi')"
+    test_code = (
+        "def test_greet():\n"
+        "    with capture() as out:\n"
+        "        greet()\n"
+        "    check_output(out, 'hi')\n"
+    )
+    result = run_exercise(student, "greet", test_code)
+    assert result["passed"] is True

--- a/frontend/src/AgentGames/Admin/AdminTutorials.jsx
+++ b/frontend/src/AgentGames/Admin/AdminTutorials.jsx
@@ -10,6 +10,7 @@ const BLANK_EXERCISE_FORM = {
   problem_markdown: '',
   starter_code: '',
   test_code: '',
+  solution: '',
 };
 
 const exerciseToForm = (exercise) => ({
@@ -18,6 +19,7 @@ const exerciseToForm = (exercise) => ({
   problem_markdown: exercise.problem_markdown,
   starter_code: exercise.starter_code,
   test_code: exercise.test_code ?? '',
+  solution: exercise.solution ?? '',
 });
 
 /**
@@ -39,9 +41,15 @@ const formToPayload = (form) => {
       problem_markdown: form.problem_markdown,
       starter_code: form.starter_code,
       test_code: form.test_code,
+      solution: form.solution,
     },
   };
 };
+
+const LEFT_TABS = [
+  { key: 'starter_code', label: 'Starter code' },
+  { key: 'solution', label: 'Solution (optional)' },
+];
 
 /**
  * Dry-run outcome panel. A normal run (even with failing tests) reuses the
@@ -81,10 +89,26 @@ function ExerciseEditor({ initialForm, isNew, onSave, onRun, onCancel }) {
   const [saving, setSaving] = useState(false);
   const [running, setRunning] = useState(false);
   const [runResult, setRunResult] = useState(null);
+  // Which code the left pane shows and Run executes: starter_code | solution
+  const [leftTab, setLeftTab] = useState('starter_code');
   const resultsRef = useRef(null);
 
   const setField = (name, value) =>
     setForm((prev) => ({ ...prev, [name]: value }));
+
+  const isDirty = Object.keys(initialForm).some(
+    (key) => form[key] !== initialForm[key]
+  );
+
+  const handleClose = () => {
+    if (
+      isDirty &&
+      !window.confirm('You have unsaved changes. Discard them?')
+    ) {
+      return;
+    }
+    onCancel();
+  };
 
   useEffect(() => {
     if (runResult) {
@@ -111,7 +135,7 @@ function ExerciseEditor({ initialForm, isNew, onSave, onRun, onCancel }) {
     setRunning(true);
     setRunResult(null);
     const result = await onRun(
-      form.starter_code,
+      form[leftTab],
       form.entry_function.trim(),
       form.test_code
     );
@@ -128,28 +152,23 @@ function ExerciseEditor({ initialForm, isNew, onSave, onRun, onCancel }) {
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
       role="dialog"
       aria-modal="true"
-      onClick={onCancel}
+      onClick={handleClose}
     >
       <div
-        className="bg-white rounded-lg shadow-xl w-[90vw] h-[98vh] flex flex-col"
+        className="relative bg-white rounded-lg shadow-xl w-[90vw] h-[98vh] flex flex-col"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
-          <h3 className="text-lg font-semibold text-gray-800">
-            {isNew ? 'New Exercise' : `Edit Exercise: ${initialForm.title}`}
-          </h3>
-          <button
-            type="button"
-            onClick={onCancel}
-            className="text-gray-400 hover:text-gray-600 text-2xl leading-none"
-            aria-label="Close"
-          >
-            ×
-          </button>
-        </div>
+        <button
+          type="button"
+          onClick={handleClose}
+          className="absolute top-2 right-3 z-10 text-gray-400 hover:text-gray-600 text-2xl leading-none"
+          aria-label="Close"
+        >
+          ×
+        </button>
 
-        <div className="flex-1 overflow-y-auto p-6 space-y-4">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="flex-1 min-h-0 flex flex-col gap-3 overflow-y-auto px-6 pt-4 pb-3">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pr-8">
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">
                 Title
@@ -187,20 +206,38 @@ function ExerciseEditor({ initialForm, isNew, onSave, onRun, onCancel }) {
             />
           </details>
 
-          <div className="grid grid-cols-2 gap-4 h-[50vh]">
+          <div className="flex-1 min-h-[18rem] grid grid-cols-2 gap-4">
             <div className="flex flex-col min-h-0">
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                Starter code — Run executes the tests against this pane
-              </label>
+              <div className="flex items-center justify-between mb-1">
+                <div className="flex gap-1">
+                  {LEFT_TABS.map((tab) => (
+                    <button
+                      key={tab.key}
+                      type="button"
+                      onClick={() => setLeftTab(tab.key)}
+                      className={`px-3 py-1 text-sm rounded-md transition-colors duration-150 ${
+                        leftTab === tab.key
+                          ? 'bg-gray-800 text-white'
+                          : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                      }`}
+                    >
+                      {tab.label}
+                    </button>
+                  ))}
+                </div>
+                <span className="text-xs text-gray-500">
+                  Run executes tests against the visible tab
+                </span>
+              </div>
               <div className="flex-1 border border-gray-300 rounded-md overflow-hidden">
                 <CodeEditor
-                  code={form.starter_code}
-                  onCodeChange={(value) => setField('starter_code', value ?? '')}
+                  code={form[leftTab]}
+                  onCodeChange={(value) => setField(leftTab, value ?? '')}
                 />
               </div>
             </div>
             <div className="flex flex-col min-h-0">
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-gray-700 mb-1 py-1">
                 Test script — test_* functions using check / check_output /
                 capture
               </label>
@@ -214,10 +251,9 @@ function ExerciseEditor({ initialForm, isNew, onSave, onRun, onCancel }) {
           </div>
 
           <p className="text-xs text-gray-500">
-            Save stores the left pane as the student's starter code — if you
-            pasted a solution to verify the tests, undo it before saving.
-            Re-running seed_tutorial.py overwrites all exercise content,
-            including tests edited here.
+            Students only ever see the starter code — the solution and test
+            script stay server-side. Re-running seed_tutorial.py overwrites
+            all exercise content, including tests and solutions edited here.
           </p>
 
           {runResult && (
@@ -247,7 +283,7 @@ function ExerciseEditor({ initialForm, isNew, onSave, onRun, onCancel }) {
             {saving ? 'Saving...' : isNew ? 'Create Exercise' : 'Save Exercise'}
           </button>
           <button
-            onClick={onCancel}
+            onClick={handleClose}
             className="px-4 py-2 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300 transition-colors duration-200"
           >
             Cancel

--- a/frontend/src/AgentGames/Admin/AdminTutorials.jsx
+++ b/frontend/src/AgentGames/Admin/AdminTutorials.jsx
@@ -1,22 +1,23 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { toast } from 'react-toastify';
 import useTutorialAPI from '../Shared/hooks/useTutorialAPI';
 import CodeEditor from '../Shared/Submission/CodeEditor';
+import ExerciseResults from '../User/ExerciseResults';
 
 const BLANK_EXERCISE_FORM = {
   title: '',
   entry_function: '',
   problem_markdown: '',
   starter_code: '',
+  test_code: '',
 };
 
-// Tests (test_code) are seed-managed and not editable here: saving an
-// exercise through this editor never touches its test script.
 const exerciseToForm = (exercise) => ({
   title: exercise.title,
   entry_function: exercise.entry_function,
   problem_markdown: exercise.problem_markdown,
   starter_code: exercise.starter_code,
+  test_code: exercise.test_code ?? '',
 });
 
 /**
@@ -37,16 +38,59 @@ const formToPayload = (form) => {
       entry_function: form.entry_function.trim(),
       problem_markdown: form.problem_markdown,
       starter_code: form.starter_code,
+      test_code: form.test_code,
     },
   };
 };
 
-function ExerciseEditor({ initialForm, isNew, onSave, onCancel }) {
+/**
+ * Dry-run outcome panel. A normal run (even with failing tests) reuses the
+ * student-facing ExerciseResults; status "error" means the run never produced
+ * test results (unsafe code, crash, broken test script, timeout), and unlike
+ * the student view it shows the traceback — the admin is debugging their own
+ * test script.
+ */
+function RunOutcome({ result }) {
+  if (result.status !== 'error') {
+    return <ExerciseResults data={result} />;
+  }
+  return (
+    <div className="space-y-2">
+      <div className="rounded-lg p-4 font-medium text-white bg-danger">
+        {result.message}
+      </div>
+      {result.traceback && (
+        <pre className="bg-[#1e1e1e] text-gray-100 rounded-lg p-3 text-sm overflow-x-auto">
+          {result.traceback}
+        </pre>
+      )}
+      {result.stdout && (
+        <div>
+          <h3 className="font-medium text-gray-800 mb-1">Print output</h3>
+          <pre className="bg-[#1e1e1e] text-gray-100 rounded-lg p-3 text-sm overflow-x-auto">
+            {result.stdout}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ExerciseEditor({ initialForm, isNew, onSave, onRun, onCancel }) {
   const [form, setForm] = useState(initialForm);
   const [saving, setSaving] = useState(false);
+  const [running, setRunning] = useState(false);
+  const [runResult, setRunResult] = useState(null);
+  const resultsRef = useRef(null);
 
   const setField = (name, value) =>
     setForm((prev) => ({ ...prev, [name]: value }));
+
+  useEffect(() => {
+    if (runResult) {
+      resultsRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [runResult]);
 
   const handleSave = async () => {
     const { payload, error } = formToPayload(form);
@@ -57,6 +101,26 @@ function ExerciseEditor({ initialForm, isNew, onSave, onCancel }) {
     setSaving(true);
     await onSave(payload);
     setSaving(false);
+  };
+
+  const handleRun = async () => {
+    if (!form.entry_function.trim()) {
+      toast.error('Entry function name is required to run tests');
+      return;
+    }
+    setRunning(true);
+    setRunResult(null);
+    const result = await onRun(
+      form.starter_code,
+      form.entry_function.trim(),
+      form.test_code
+    );
+    setRunning(false);
+    if (!result.success) {
+      toast.error(result.error);
+      return;
+    }
+    setRunResult(result.data);
   };
 
   return (
@@ -99,7 +163,7 @@ function ExerciseEditor({ initialForm, isNew, onSave, onCancel }) {
             </div>
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">
-                Entry function (the function name the tests call)
+                Entry function (the function name every submission must define)
               </label>
               <input
                 type="text"
@@ -111,37 +175,68 @@ function ExerciseEditor({ initialForm, isNew, onSave, onCancel }) {
             </div>
           </div>
 
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+          <details open={isNew}>
+            <summary className="text-sm font-medium text-gray-700 cursor-pointer select-none">
               Problem (Markdown shown to the student)
-            </label>
+            </summary>
             <textarea
               value={form.problem_markdown}
               onChange={(e) => setField('problem_markdown', e.target.value)}
-              rows={10}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md font-mono text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              rows={8}
+              className="mt-2 w-full px-3 py-2 border border-gray-300 rounded-md font-mono text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
-          </div>
+          </details>
 
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Starter code
-            </label>
-            <div className="h-56 border border-gray-300 rounded-md overflow-hidden">
-              <CodeEditor
-                code={form.starter_code}
-                onCodeChange={(value) => setField('starter_code', value ?? '')}
-              />
+          <div className="grid grid-cols-2 gap-4 h-[50vh]">
+            <div className="flex flex-col min-h-0">
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Starter code — Run executes the tests against this pane
+              </label>
+              <div className="flex-1 border border-gray-300 rounded-md overflow-hidden">
+                <CodeEditor
+                  code={form.starter_code}
+                  onCodeChange={(value) => setField('starter_code', value ?? '')}
+                />
+              </div>
+            </div>
+            <div className="flex flex-col min-h-0">
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Test script — test_* functions using check / check_output /
+                capture
+              </label>
+              <div className="flex-1 border border-gray-300 rounded-md overflow-hidden">
+                <CodeEditor
+                  code={form.test_code}
+                  onCodeChange={(value) => setField('test_code', value ?? '')}
+                />
+              </div>
             </div>
           </div>
 
           <p className="text-xs text-gray-500">
-            Tests are a seed-managed Python test script and are not editable
-            here — saving this form never changes the exercise's tests.
+            Save stores the left pane as the student's starter code — if you
+            pasted a solution to verify the tests, undo it before saving.
+            Re-running seed_tutorial.py overwrites all exercise content,
+            including tests edited here.
           </p>
+
+          {runResult && (
+            <div ref={resultsRef}>
+              <RunOutcome result={runResult} />
+            </div>
+          )}
         </div>
 
         <div className="flex gap-3 px-6 py-4 border-t border-gray-200">
+          <button
+            onClick={handleRun}
+            disabled={running}
+            className={`px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 transition-colors duration-200 ${
+              running ? 'opacity-70 cursor-not-allowed' : ''
+            }`}
+          >
+            {running ? 'Running...' : 'Run Tests'}
+          </button>
           <button
             onClick={handleSave}
             disabled={saving}
@@ -167,6 +262,7 @@ function AdminTutorials() {
   const {
     getTutorials,
     getTutorialAdmin,
+    runExerciseTests,
     createTutorial,
     updateTutorial,
     deleteTutorial,
@@ -580,6 +676,7 @@ function AdminTutorials() {
                       initialForm={editing.form}
                       isNew={editing.id === null}
                       onSave={handleSaveExercise}
+                      onRun={runExerciseTests}
                       onCancel={() => setEditing(null)}
                     />
                   )}

--- a/frontend/src/AgentGames/Admin/AdminTutorials.jsx
+++ b/frontend/src/AgentGames/Admin/AdminTutorials.jsx
@@ -8,20 +8,15 @@ const BLANK_EXERCISE_FORM = {
   entry_function: '',
   problem_markdown: '',
   starter_code: '',
-  testCases: [{ name: '', argsText: '[]', expectedText: 'null' }],
 };
 
-// Test cases are edited as JSON text fields; convert to/from the API shape.
+// Tests (test_code) are seed-managed and not editable here: saving an
+// exercise through this editor never touches its test script.
 const exerciseToForm = (exercise) => ({
   title: exercise.title,
   entry_function: exercise.entry_function,
   problem_markdown: exercise.problem_markdown,
   starter_code: exercise.starter_code,
-  testCases: exercise.test_cases.map((testCase) => ({
-    name: testCase.name,
-    argsText: JSON.stringify(testCase.args),
-    expectedText: JSON.stringify(testCase.expected),
-  })),
 });
 
 /**
@@ -36,39 +31,12 @@ const formToPayload = (form) => {
   if (!form.problem_markdown.trim()) {
     return { error: 'Problem markdown is required' };
   }
-  const test_cases = [];
-  for (let i = 0; i < form.testCases.length; i++) {
-    const testCase = form.testCases[i];
-    if (!testCase.name.trim()) {
-      return { error: `Test case ${i + 1} needs a name` };
-    }
-    let args;
-    try {
-      args = JSON.parse(testCase.argsText);
-    } catch {
-      return { error: `Test case ${i + 1}: args is not valid JSON` };
-    }
-    if (!Array.isArray(args)) {
-      return { error: `Test case ${i + 1}: args must be a JSON list, e.g. [1, 2]` };
-    }
-    let expected;
-    try {
-      expected = JSON.parse(testCase.expectedText);
-    } catch {
-      return { error: `Test case ${i + 1}: expected is not valid JSON` };
-    }
-    test_cases.push({ name: testCase.name.trim(), args, expected });
-  }
-  if (test_cases.length === 0) {
-    return { error: 'An exercise needs at least one test case' };
-  }
   return {
     payload: {
       title: form.title.trim(),
       entry_function: form.entry_function.trim(),
       problem_markdown: form.problem_markdown,
       starter_code: form.starter_code,
-      test_cases,
     },
   };
 };
@@ -79,29 +47,6 @@ function ExerciseEditor({ initialForm, isNew, onSave, onCancel }) {
 
   const setField = (name, value) =>
     setForm((prev) => ({ ...prev, [name]: value }));
-
-  const setTestCaseField = (index, name, value) =>
-    setForm((prev) => ({
-      ...prev,
-      testCases: prev.testCases.map((testCase, i) =>
-        i === index ? { ...testCase, [name]: value } : testCase
-      ),
-    }));
-
-  const addTestCase = () =>
-    setForm((prev) => ({
-      ...prev,
-      testCases: [
-        ...prev.testCases,
-        { name: '', argsText: '[]', expectedText: 'null' },
-      ],
-    }));
-
-  const removeTestCase = (index) =>
-    setForm((prev) => ({
-      ...prev,
-      testCases: prev.testCases.filter((_, i) => i !== index),
-    }));
 
   const handleSave = async () => {
     const { payload, error } = formToPayload(form);
@@ -190,65 +135,10 @@ function ExerciseEditor({ initialForm, isNew, onSave, onCancel }) {
             </div>
           </div>
 
-          <div>
-            <div className="flex justify-between items-center mb-2">
-              <label className="block text-sm font-medium text-gray-700">
-                Test cases — params is a JSON list of arguments, return is the
-                expected JSON return value
-              </label>
-              <button
-                onClick={addTestCase}
-                className="px-3 py-1 text-sm bg-blue-100 text-blue-700 rounded-md hover:bg-blue-200 transition-colors duration-200"
-              >
-                + Add test case
-              </button>
-            </div>
-            <div className="hidden md:flex gap-2 mb-1 text-xs font-medium text-gray-500">
-              <span className="flex-[3]">Exercise name</span>
-              <span className="flex-[5]">Function params</span>
-              <span className="flex-[2]">Function return</span>
-              <span className="w-20 flex-shrink-0" />
-            </div>
-            <div className="space-y-2">
-              {form.testCases.map((testCase, index) => (
-                <div
-                  key={index}
-                  className="flex flex-col md:flex-row gap-2 items-stretch md:items-center"
-                >
-                  <input
-                    type="text"
-                    value={testCase.name}
-                    onChange={(e) => setTestCaseField(index, 'name', e.target.value)}
-                    placeholder="Test name"
-                    className="flex-[3] min-w-0 px-2 py-1 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
-                  />
-                  <input
-                    type="text"
-                    value={testCase.argsText}
-                    onChange={(e) => setTestCaseField(index, 'argsText', e.target.value)}
-                    placeholder='e.g. [{"Alice": 30}, "Alice"]'
-                    className="flex-[5] min-w-0 px-2 py-1 border border-gray-300 rounded font-mono text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
-                  />
-                  <input
-                    type="text"
-                    value={testCase.expectedText}
-                    onChange={(e) =>
-                      setTestCaseField(index, 'expectedText', e.target.value)
-                    }
-                    placeholder="e.g. 30"
-                    className="flex-[2] min-w-0 px-2 py-1 border border-gray-300 rounded font-mono text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
-                  />
-                  <button
-                    onClick={() => removeTestCase(index)}
-                    className="w-20 flex-shrink-0 px-2 py-1 text-sm text-red-600 hover:bg-red-50 rounded transition-colors duration-200"
-                    title="Remove test case"
-                  >
-                    Remove
-                  </button>
-                </div>
-              ))}
-            </div>
-          </div>
+          <p className="text-xs text-gray-500">
+            Tests are a seed-managed Python test script and are not editable
+            here — saving this form never changes the exercise's tests.
+          </p>
         </div>
 
         <div className="flex gap-3 px-6 py-4 border-t border-gray-200">
@@ -642,9 +532,7 @@ function AdminTutorials() {
                             {exercise.title}
                           </p>
                           <p className="text-xs text-gray-500 font-mono truncate">
-                            {exercise.entry_function}() ·{' '}
-                            {exercise.test_cases.length} test case
-                            {exercise.test_cases.length === 1 ? '' : 's'}
+                            {exercise.entry_function}()
                           </p>
                         </div>
                         <div className="flex items-center gap-1 flex-shrink-0">

--- a/frontend/src/AgentGames/AgentHome.jsx
+++ b/frontend/src/AgentGames/AgentHome.jsx
@@ -10,7 +10,7 @@ const Homepage = () => {
       <section className="bg-gradient-to-br from-league-blue to-primary py-20">
         <div className="container mx-auto px-6 text-center">
           <h1 className="text-4xl md:text-6xl font-bold text-white mb-6">
-            Welcome to Agent Games
+           Python Programming Gamified
           </h1>
           <p className="text-xl text-league-text max-w-3xl mx-auto mb-10">
             Open Source platform for programming python agents that compete in strategic games. Great for universities, computing clubs and Computer Science enthusiasts

--- a/frontend/src/AgentGames/Shared/hooks/useTutorialAPI.js
+++ b/frontend/src/AgentGames/Shared/hooks/useTutorialAPI.js
@@ -280,7 +280,8 @@ export const useTutorialAPI = () => {
     [adminRequest]
   );
 
-  /** exercise = { title, problem_markdown, starter_code, entry_function, test_cases } */
+  /** exercise = { title, problem_markdown, starter_code, entry_function }
+   *  (tests are a seed-managed test script, never sent from the admin UI) */
   const createExercise = useCallback(
     (tutorialId, exercise) =>
       adminRequest(`/tutorial/${tutorialId}/exercises`, 'POST', exercise),

--- a/frontend/src/AgentGames/Shared/hooks/useTutorialAPI.js
+++ b/frontend/src/AgentGames/Shared/hooks/useTutorialAPI.js
@@ -257,9 +257,25 @@ export const useTutorialAPI = () => {
     }
   }, [apiUrl, accessToken]);
 
-  /** Get one tutorial with full exercise definitions (incl. test cases). */
+  /** Get one tutorial with full exercise definitions (incl. test scripts). */
   const getTutorialAdmin = useCallback(
     (tutorialId) => adminRequest(`/admin/tutorial/${tutorialId}`),
+    [adminRequest]
+  );
+
+  /**
+   * Dry-run a test script against code without saving anything (backs the
+   * exercise editor's Run button). Always resolves with the full run result
+   * — { status, message, passed, test_results, traceback, stdout, ... } —
+   * so failing tests and broken test scripts both render, never toast.
+   */
+  const runExerciseTests = useCallback(
+    (code, entryFunction, testCode) =>
+      adminRequest('/admin/run-exercise', 'POST', {
+        code,
+        entry_function: entryFunction,
+        test_code: testCode,
+      }),
     [adminRequest]
   );
 
@@ -280,8 +296,8 @@ export const useTutorialAPI = () => {
     [adminRequest]
   );
 
-  /** exercise = { title, problem_markdown, starter_code, entry_function }
-   *  (tests are a seed-managed test script, never sent from the admin UI) */
+  /** exercise = { title, problem_markdown, starter_code, entry_function,
+   *  test_code } */
   const createExercise = useCallback(
     (tutorialId, exercise) =>
       adminRequest(`/tutorial/${tutorialId}/exercises`, 'POST', exercise),
@@ -317,6 +333,7 @@ export const useTutorialAPI = () => {
     getExerciseSubmissions,
     submitExercise,
     getTutorialAdmin,
+    runExerciseTests,
     createTutorial,
     updateTutorial,
     deleteTutorial,

--- a/frontend/src/AgentGames/User/ExerciseResults.jsx
+++ b/frontend/src/AgentGames/User/ExerciseResults.jsx
@@ -1,9 +1,13 @@
 import React from 'react';
 
+const isMultiline = (value) =>
+    typeof value === 'string' && value.includes('\n');
+
 /**
- * Per-test-case results panel for tutorial exercises: a pass/fail summary
- * banner, one row per test case (call, expected vs actual, error), and any
- * captured print output.
+ * Per-test results panel for tutorial exercises: a pass/fail summary banner,
+ * one row per test (name, expected vs actual, error), and any captured print
+ * output. Multiline expected/got values (print-checking exercises) render in
+ * a <pre> block so real newlines show instead of "\n" escapes.
  */
 function ExerciseResults({ data }) {
     if (!data) return null;
@@ -41,7 +45,7 @@ function ExerciseResults({ data }) {
                             <span>{test.name}</span>
                         </div>
                         <div className="mt-1 ml-7 font-mono text-sm text-ui-dark/80">
-                            <div>{test.call}</div>
+                            {test.call && <div>{test.call}</div>}
                             {!test.passed && (
                                 <div className="mt-1">
                                     {test.error ? (
@@ -50,15 +54,29 @@ function ExerciseResults({ data }) {
                                         <>
                                             <div>
                                                 expected:{" "}
-                                                <span className="text-success">
-                                                    {JSON.stringify(test.expected)}
-                                                </span>
+                                                {isMultiline(test.expected) ? (
+                                                    <pre className="mt-1 whitespace-pre-wrap rounded bg-success/10 p-2 text-success">
+                                                        {test.expected}
+                                                    </pre>
+                                                ) : (
+                                                    <span className="text-success">
+                                                        {JSON.stringify(test.expected)}
+                                                    </span>
+                                                )}
                                             </div>
                                             <div>
                                                 got:{" "}
-                                                <span className="text-danger">
-                                                    {test.actual ?? "nothing"}
-                                                </span>
+                                                {isMultiline(test.actual) ? (
+                                                    <pre className="mt-1 whitespace-pre-wrap rounded bg-danger/10 p-2 text-danger">
+                                                        {test.actual}
+                                                    </pre>
+                                                ) : (
+                                                    <span className="text-danger">
+                                                        {test.actual === ""
+                                                            ? "(no output)"
+                                                            : test.actual ?? "nothing"}
+                                                    </span>
+                                                )}
                                             </div>
                                         </>
                                     )}


### PR DESCRIPTION
- Exercise tests moved from declarative JSON to a Python test script. The Exercise.test_cases JSON column (a list of {name, args, expected} I/O pairs) is replaced by a test_code TEXT column holding an admin-authored script. Two idempotent migrations add test_code + solution and drop test_cases with no back-compat path.
- New test-script runner (backend/tasks/exercise_test_code.py). The script is admin-trusted, so it skips the AST allowlist and is exec'd into the same namespace as the student's code — meaning tests can call multiple student functions and assert on printed output, not just one entry function's return value. It exposes three injected helpers (check, check_output, capture) and emits result rows in the same shape the old JSON loop produced, so the frontend renders both identically. An exercise whose script produces no rows now errors loudly ("This exercise defines no tests") instead of passing vacuously.
- New admin dry-run endpoint POST /admin/run-exercise. Stateless (no exercise ID), so a test script can be run against code — typically the new optional solution reference implementation — before the exercise is ever saved. Every outcome returns 200 with the full result including the traceback, since the caller is the person debugging the script.
- Admin exercise editor rebuilt around this (AdminTutorials.jsx, +runExerciseTests in useTutorialAPI.js): the test-case form is gone, replaced by test-script/solution editors and a Run button. seed_tutorial.py shrinks by ~700 lines as hand-written JSON cases become scripts.
- Tests updated throughout — a new test_exercise_test_code.py unit suite (200 lines) plus reworked tutorial router/admin, game-workflow, and demo tests.